### PR TITLE
Add `source_id` to QueueMessage

### DIFF
--- a/agentfile/agent_server/base.py
+++ b/agentfile/agent_server/base.py
@@ -4,9 +4,10 @@ from typing import Dict, List
 from agentfile.agent_server.types import _Task, _TaskSate, _TaskStep, _TaskStepOutput
 from agentfile.message_consumers.base import BaseMessageQueueConsumer
 from agentfile.types import AgentDefinition
+from agentfile.message_publishers.publisher import MessageQueuePublisherMixin
 
 
-class BaseAgentServer(ABC):
+class BaseAgentServer(MessageQueuePublisherMixin, ABC):
     @property
     @abstractmethod
     def agent_definition(self) -> AgentDefinition:

--- a/agentfile/agent_server/fastapi.py
+++ b/agentfile/agent_server/fastapi.py
@@ -177,6 +177,7 @@ class FastAPIAgentServer(BaseAgentServer):
                     )
                     await self.message_queue.publish(
                         QueueMessage(
+                            source_id=self.id_,
                             type="control_plane",
                             action=ActionTypes.COMPLETED_TASK,
                             data=TaskResult(

--- a/agentfile/control_plane/base.py
+++ b/agentfile/control_plane/base.py
@@ -10,9 +10,10 @@ from abc import ABC, abstractmethod
 
 from agentfile.message_consumers.base import BaseMessageQueueConsumer
 from agentfile.types import AgentDefinition, FlowDefinition, TaskDefinition, TaskResult
+from agentfile.message_publishers.publisher import MessageQueuePublisherMixin
 
 
-class BaseControlPlane(ABC):
+class BaseControlPlane(MessageQueuePublisherMixin, ABC):
     @abstractmethod
     def get_consumer(self) -> BaseMessageQueueConsumer:
         """

--- a/agentfile/control_plane/fastapi.py
+++ b/agentfile/control_plane/fastapi.py
@@ -157,7 +157,10 @@ class FastAPIControlPlane(BaseControlPlane):
 
         await self.message_queue.publish(
             QueueMessage(
-                type=agent_id, data=task_def.model_dump(), action=ActionTypes.NEW_TASK
+                source_id=self.id_,
+                type=agent_id,
+                data=task_def.model_dump(),
+                action=ActionTypes.NEW_TASK,
             )
         )
 
@@ -173,7 +176,10 @@ class FastAPIControlPlane(BaseControlPlane):
 
         await self.message_queue.publish(
             QueueMessage(
-                type="human", action=ActionTypes.COMPLETED_TASK, data=task_result.result
+                source_id=self.id_,
+                type="human",
+                action=ActionTypes.COMPLETED_TASK,
+                data=task_result.result,
             )
         )
 

--- a/agentfile/launchers/local.py
+++ b/agentfile/launchers/local.py
@@ -7,6 +7,7 @@ from agentfile.message_consumers.base import BaseMessageQueueConsumer
 from agentfile.message_queues.simple import SimpleMessageQueue
 from agentfile.messages.base import QueueMessage
 from agentfile.types import ActionTypes, TaskDefinition
+from agentfile.message_publishers.publisher import MessageQueuePublisherMixin
 
 
 class HumanMessageConsumer(BaseMessageQueueConsumer):
@@ -22,7 +23,7 @@ class HumanMessageConsumer(BaseMessageQueueConsumer):
             await self.message_handler[action](result=message.data)
 
 
-class LocalLauncher:
+class LocalLauncher(MessageQueuePublisherMixin):
     def __init__(
         self,
         agent_servers: List[BaseAgentServer],
@@ -64,6 +65,7 @@ class LocalLauncher:
         # publish initial task
         await self.message_queue.publish(
             QueueMessage(
+                source_id=self.id_,
                 type="control_plane",
                 action=ActionTypes.NEW_TASK,
                 data=TaskDefinition(input=initial_task).model_dump(),

--- a/agentfile/message_publishers/publisher.py
+++ b/agentfile/message_publishers/publisher.py
@@ -1,0 +1,12 @@
+import uuid
+from abc import ABC
+from typing import Any
+
+
+class MessageQueuePublisherMixin(ABC):
+    """PublisherMixing."""
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        if not hasattr(self, "id_"):
+            self.id_ = f"{self.__class__.__qualname__}-{uuid.uuid4()}"

--- a/agentfile/messages/base.py
+++ b/agentfile/messages/base.py
@@ -8,7 +8,8 @@ from agentfile.types import ActionTypes
 
 
 class QueueMessage(BaseModel):
-    id_: str = Field(default_factory=lambda: str(uuid.uuid4))
+    id_: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    source_id: str = Field(description="Id of publisher.")
     data: Optional[Any] = Field(default_factory=None)
     action: Optional[ActionTypes] = None
     type: str = Field(

--- a/tests/message_queue_consumers/test_base.py
+++ b/tests/message_queue_consumers/test_base.py
@@ -26,8 +26,8 @@ async def test_consumer_consumes_messages() -> None:
     # Act
     await consumer_one.start_consuming(message_queue=mq)
     await asyncio.sleep(0.1)
-    await mq.publish(QueueMessage(id_="1"))
-    await mq.publish(QueueMessage(id_="2"))
+    await mq.publish(QueueMessage(source_id="test", id_="1"))
+    await mq.publish(QueueMessage(source_id="test", id_="2"))
 
     # Give some time for last message to get published and sent to consumers
     await asyncio.sleep(0.5)

--- a/tests/message_queues/test_simple.py
+++ b/tests/message_queues/test_simple.py
@@ -73,9 +73,9 @@ async def test_simple_publish_consumer() -> None:
     await mq.register_consumer(consumer_two)
 
     # Act
-    await mq.publish(QueueMessage(id_="1"))
-    await mq.publish(QueueMessage(id_="2", type="two"))
-    await mq.publish(QueueMessage(id_="3", type="two"))
+    await mq.publish(QueueMessage(source_id="test", id_="1"))
+    await mq.publish(QueueMessage(source_id="test", id_="2", type="two"))
+    await mq.publish(QueueMessage(source_id="test", id_="3", type="two"))
 
     # Give some time for last message to get published and sent to consumers
     await asyncio.sleep(0.5)


### PR DESCRIPTION
- Adds a `MessageQueuePublisherMixin` to create an `id_` attr on the class if it doesn't yet exist.

(Wonder if we should do more than a Mixin here...)