### PR TITLE
Fix MessageQueuePublisherMixin

### DIFF
--- a/agentfile/message_publishers/publisher.py
+++ b/agentfile/message_publishers/publisher.py
@@ -1,12 +1,22 @@
-import uuid
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Any
+from agentfile.messages.base import QueueMessage
+from agentfile.message_queues.base import BaseMessageQueue
 
 
 class MessageQueuePublisherMixin(ABC):
     """PublisherMixing."""
 
-    def __init__(self, **kwargs: Any):
-        super().__init__(**kwargs)
-        if not hasattr(self, "id_"):
-            self.id_ = f"{self.__class__.__qualname__}-{uuid.uuid4()}"
+    @property
+    @abstractmethod
+    def publisher_id(self) -> str:
+        ...
+
+    @property
+    @abstractmethod
+    def message_queue(self) -> BaseMessageQueue:
+        ...
+
+    async def publish(self, message: QueueMessage, **kwargs: Any) -> Any:
+        """Publish message."""
+        return await self.message_queue.publish(message, **kwargs)

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -4,12 +4,17 @@ from llama_index.core.agent import ReActAgent
 from agentfile.agent_server import FastAPIAgentServer
 from agentfile.message_queues.simple import SimpleMessageQueue
 
+from unittest.mock import patch, MagicMock
 
-def test_init() -> None:
+
+@patch("agentfile.agent_server.fastapi.uuid")
+def test_init(mock_uuid: MagicMock) -> None:
+    mock_uuid.uuid4.return_value = "mock"
     agent = ReActAgent.from_tools([], llm=MockLLM())
+    mq = SimpleMessageQueue()
     server = FastAPIAgentServer(
         agent,
-        SimpleMessageQueue(),
+        mq,
         running=False,
         description="Test Agent Server",
         step_interval=0.5,
@@ -19,3 +24,5 @@ def test_init() -> None:
     assert server.running is False
     assert server.description == "Test Agent Server"
     assert server.step_interval == 0.5
+    assert server.message_queue == mq
+    assert server.publisher_id == "FastAPIAgentServer-mock"


### PR DESCRIPTION
- Previous checked in mixin had __init__() which is not good practice
- Fix by using @property and @abstractmethod which is a pattern we've adopted elsewhere already (i.e., `BaseAgentServer` for `agent_definition`)