### PR TITLE
stop asyncio from swallowing errors

### DIFF
--- a/llama_agents/launchers/local.py
+++ b/llama_agents/launchers/local.py
@@ -121,6 +121,13 @@ class LocalLauncher(MessageQueuePublisherMixin):
             await asyncio.sleep(0.1)
             signal.signal(signal.SIGINT, shutdown_handler)
 
+            for task in bg_tasks:
+                if task.done() and task.exception():  # type: ignore
+                    raise task.exception()  # type: ignore
+
+            if mq_task.done() and mq_task.exception():  # type: ignore
+                raise mq_task.exception()  # type: ignore
+
             if self.result:
                 break
 


### PR DESCRIPTION
Technically, these tasks should never be done, and if they are, there was an exception. So lets report that instead of swallowing the error