### PR TITLE
consistent ids in consumers, and deregister after launch local

### DIFF
--- a/llama_agents/control_plane/server.py
+++ b/llama_agents/control_plane/server.py
@@ -144,11 +144,13 @@ class ControlPlaneServer(BaseControlPlane):
     def as_consumer(self, remote: bool = False) -> BaseMessageQueueConsumer:
         if remote:
             return RemoteMessageConsumer(
+                id_=self.publisher_id,
                 url=f"http://{self.host}:{self.port}/process_message",
                 message_type="control_plane",
             )
 
         return CallableMessageConsumer(
+            id_=self.publisher_id,
             message_type="control_plane",
             handler=self.process_message,
         )

--- a/llama_agents/message_queues/simple.py
+++ b/llama_agents/message_queues/simple.py
@@ -211,13 +211,17 @@ class SimpleMessageQueue(BaseMessageQueue):
 
         if message_type_str not in self.consumers:
             self.consumers[message_type_str] = {consumer.id_: consumer}
-            logger.info(f"Consumer {consumer.id_} has been registered.")
+            logger.info(
+                f"Consumer {consumer.id_}: {message_type_str} has been registered."
+            )
         else:
             if consumer.id_ in self.consumers[message_type_str]:
                 raise ValueError("Consumer has already been added.")
 
             self.consumers[message_type_str][consumer.id_] = consumer
-            logger.info(f"Consumer {consumer.id_} has been registered.")
+            logger.info(
+                f"Consumer {consumer.id_}: {message_type_str} has been registered."
+            )
 
         if message_type_str not in self.queues:
             self.queues[message_type_str] = deque()
@@ -232,7 +236,9 @@ class SimpleMessageQueue(BaseMessageQueue):
     async def deregister_consumer(self, consumer: BaseMessageQueueConsumer) -> None:
         message_type_str = consumer.message_type
         if consumer.id_ not in self.consumers.get(message_type_str, {}):
-            raise ValueError("No consumer found for associated message type.")
+            raise ValueError(
+                f"No consumer found for associated message type. {consumer.id_}: {message_type_str}"
+            )
 
         del self.consumers[message_type_str][consumer.id_]
         if len(self.consumers[message_type_str]) == 0:

--- a/llama_agents/services/agent.py
+++ b/llama_agents/services/agent.py
@@ -258,11 +258,13 @@ class AgentService(BaseService):
         if remote:
             url = f"http://{self.host}:{self.port}{self._app.url_path_for('process_message')}"
             return RemoteMessageConsumer(
+                id_=self.publisher_id,
                 url=url,
                 message_type=self.service_name,
             )
 
         return CallableMessageConsumer(
+            id_=self.publisher_id,
             message_type=self.service_name,
             handler=self.process_message,
         )

--- a/llama_agents/services/human.py
+++ b/llama_agents/services/human.py
@@ -189,11 +189,13 @@ class HumanService(BaseService):
         if remote:
             url = f"http://{self.host}:{self.port}{self._app.url_path_for('process_message')}"
             return RemoteMessageConsumer(
+                id_=self.publisher_id,
                 url=url,
                 message_type=self.service_name,
             )
 
         return CallableMessageConsumer(
+            id_=self.publisher_id,
             message_type=self.service_name,
             handler=self.process_message,
         )

--- a/llama_agents/services/tool.py
+++ b/llama_agents/services/tool.py
@@ -188,10 +188,12 @@ class ToolService(BaseService):
         if remote:
             url = f"http://{self.host}:{self.port}{self._app.url_path_for('process_message')}"
             return RemoteMessageConsumer(
+                id_=self.publisher_id,
                 url=url,
                 message_type=self.service_name,
             )
         return CallableMessageConsumer(
+            id_=self.publisher_id,
             message_type=self.service_name,
             handler=self.process_message,
         )

--- a/llama_agents/tools/agent_service_tool.py
+++ b/llama_agents/tools/agent_service_tool.py
@@ -129,6 +129,7 @@ class AgentServiceTool(MessageQueuePublisherMixin, AsyncBaseTool, BaseModel):
 
     def as_consumer(self) -> BaseMessageQueueConsumer:
         return CallableMessageConsumer(
+            id_=self.publisher_id,
             message_type=self.publisher_id,
             handler=self.process_message,
         )

--- a/llama_agents/tools/meta_service_tool.py
+++ b/llama_agents/tools/meta_service_tool.py
@@ -140,6 +140,7 @@ class MetaServiceTool(MessageQueuePublisherMixin, AsyncBaseTool, BaseModel):
 
     def as_consumer(self) -> BaseMessageQueueConsumer:
         return CallableMessageConsumer(
+            id_=self.publisher_id,
             message_type=self.publisher_id,
             handler=self.process_message,
         )


### PR DESCRIPTION
Two issues
- launch_single wasn't cleaning up after a launch (need to degregister and make it idempotent!)
- consumer ids were random each time (now we use a consistent id)