### PR TITLE
surface errors better in agent service

### DIFF
--- a/llama_agents/services/agent.py
+++ b/llama_agents/services/agent.py
@@ -227,6 +227,18 @@ class AgentService(BaseService):
                     import signal
 
                     signal.raise_signal(signal.SIGINT)
+                else:
+                    await self.message_queue.publish(
+                        QueueMessage(
+                            type=CONTROL_PLANE_NAME,
+                            action=ActionTypes.COMPLETED_TASK,
+                            data=TaskResult(
+                                task_id=task_id,
+                                history=[],
+                                result=f"Error during processing: {e}",
+                            ).model_dump(),
+                        )
+                    )
 
                 continue
 


### PR DESCRIPTION
When an agent hits an exception, it should have the option of surfacing that to the orchestrator