### PR TITLE
[FIX] Register remote consumer duplication

### DIFF
--- a/llama_agents/message_queues/simple.py
+++ b/llama_agents/message_queues/simple.py
@@ -218,7 +218,10 @@ class SimpleMessageQueue(BaseMessageQueue):
             )
         else:
             if consumer.id_ in self.consumers[message_type_str]:
-                raise ValueError("Consumer has already been added.")
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Consumer with the same id_ has already been previously added.",
+                )
             self.consumers[message_type_str][consumer.id_] = consumer
             logger.info(
                 f"Consumer {consumer.id_}: {message_type_str} has been registered."

--- a/llama_agents/message_queues/simple.py
+++ b/llama_agents/message_queues/simple.py
@@ -268,8 +268,9 @@ class SimpleMessageQueue(BaseMessageQueue):
     async def deregister_consumer(self, consumer: BaseMessageQueueConsumer) -> None:
         message_type_str = consumer.message_type
         if consumer.id_ not in self.consumers.get(message_type_str, {}):
-            raise ValueError(
-                f"No consumer found for associated message type. {consumer.id_}: {message_type_str}"
+            raise HTTPException(
+                detail=f"No consumer found for associated message type. {consumer.id_}: {message_type_str}",
+                status_code=status.HTTP_404_NOT_FOUND,
             )
 
         del self.consumers[message_type_str][consumer.id_]

--- a/tests/message_queues/test_simple.py
+++ b/tests/message_queues/test_simple.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+from fastapi import HTTPException
 from pydantic import PrivateAttr
 from typing import Any, List
 
@@ -27,7 +28,7 @@ async def test_simple_register_consumer() -> None:
     # Act
     await mq.register_consumer(consumer_one)
     await mq.register_consumer(consumer_two)
-    with pytest.raises(ValueError):
+    with pytest.raises(HTTPException):
         await mq.register_consumer(consumer_two)
 
     # Assert
@@ -54,7 +55,7 @@ async def test_simple_deregister_consumer() -> None:
     # Act
     await mq.deregister_consumer(consumer_one)
     await mq.deregister_consumer(consumer_three)
-    with pytest.raises(ValueError):
+    with pytest.raises(HTTPException):
         await mq.deregister_consumer(consumer_three)
 
     # Assert


### PR DESCRIPTION
- Fixes the bug when a remote consumer with the same url gets registered to a SimpleMessageQueue
- Checks for existing remote consumers with the same url, if exists raises HttpException with status code 409

fixes #54 

First `/register_consumer` (Success, 200)
<img width="1298" alt="image" src="https://github.com/run-llama/llama-agents/assets/92402603/f763e205-9f48-4eeb-885c-148b7df3968c">

Repeated call to `/register_consumer` (Fail, 409)
<img width="1298" alt="image" src="https://github.com/run-llama/llama-agents/assets/92402603/5b775722-dc53-461e-9007-e11a373c6969">

Associated server logs
<img width="967" alt="image" src="https://github.com/run-llama/llama-agents/assets/92402603/e78d2da6-7e23-4e13-9f10-122f7990f01f">

