### PR TITLE
[FIX] - `ServiceComponent` doesn't have field _cur_input_keys Error

### DIFF
--- a/llama_agents/tools/service_component.py
+++ b/llama_agents/tools/service_component.py
@@ -41,8 +41,7 @@ class ServiceComponent(CustomQueryComponent):
         module_type: ModuleType = ModuleType.AGENT,
     ) -> None:
         super().__init__(name=name, description=description, module_type=module_type)
-        if input_keys is not None:
-            self._cur_input_keys = input_keys or InputKeys.from_keys({"input"})
+        self._cur_input_keys = input_keys or InputKeys.from_keys({"input"})
 
     @classmethod
     def from_service_definition(


### PR DESCRIPTION
I was running into an Error saying that `ServiceComponent` doesn't have field `_cur_input_keys` that gets returned under the property `input_keys` (or see [L.85](https://github.com/run-llama/llama-agents/blob/c355bf9c0c4ca64a55eb733e74e82013c233b7b8/llama_agents/tools/service_component.py#L85))

This PR fixes the `__init__` of this class so that we have a value for `_cur_input_keys`.

