### PR TITLE
[FIX] Remove overriding of `publish` in `BaseService`

### DIFF
--- a/llama_agents/services/base.py
+++ b/llama_agents/services/base.py
@@ -55,13 +55,6 @@ class BaseService(MessageQueuePublisherMixin, ABC, BaseModel):
         """Process a message."""
         ...
 
-    async def publish(self, message: QueueMessage, **kwargs: Any) -> None:
-        """Publish a message to another service."""
-        message.publisher_id = self.publisher_id
-        await self.message_queue.publish(
-            message, callback=self.publish_callback, **kwargs
-        )
-
     @abstractmethod
     async def launch_local(self) -> asyncio.Task:
         """Launch the service in-process."""


### PR DESCRIPTION
- `BaseService` has `MessageQueuePublisherMixin` and we should use `publish()` method that comes from this
- This PR removes the `publish` method that overrides that from the mixin (and they amount to the same impl in fact)