### PR TITLE
[FIX] Add missing lifespan in fastapi app for HumanService

### DIFF
--- a/llama_agents/services/agent.py
+++ b/llama_agents/services/agent.py
@@ -214,6 +214,7 @@ class AgentService(BaseService):
 
     async def processing_loop(self) -> None:
         """The processing loop for the agent."""
+        logger.info("Processing initiated.")
         while True:
             try:
                 if not self.running:

--- a/llama_agents/services/component.py
+++ b/llama_agents/services/component.py
@@ -156,6 +156,7 @@ class ComponentService(BaseService):
 
     async def processing_loop(self) -> None:
         """The processing loop for the service."""
+        logger.info("Processing initiated.")
         while True:
             if not self.running:
                 await asyncio.sleep(self.step_interval)

--- a/llama_agents/services/tool.py
+++ b/llama_agents/services/tool.py
@@ -181,6 +181,7 @@ class ToolService(BaseService):
 
     async def processing_loop(self) -> None:
         """The processing loop for the service."""
+        logger.info("Processing initiated.")
         while True:
             if not self.running:
                 await asyncio.sleep(self.step_interval)


### PR DESCRIPTION
Turns out that we were missing the definition and application of lifespan() in `HumanService` app so when it was getting launched, the processing loop was not starting.
- This PR adds the missing `lifespan` to `HumanService`
- Adds log lines for all services to indicate that `processing` has started.