### PR TITLE
Use other sources for agent orchestrator summary

### DIFF
--- a/llama_agents/orchestrators/agent.py
+++ b/llama_agents/orchestrators/agent.py
@@ -164,6 +164,12 @@ class AgentOrchestrator(BaseOrchestrator):
         if len(new_history) > 1:
             summarize_prompt_str = self.summarize_prompt.format(history=new_history_str)
             summary = await self.llm.acomplete(summarize_prompt_str)
+        elif len(new_history) == 1:
+            summary = new_history[0].content
+        elif result.result:
+            summary = result.result
+        else:
+            summary = "There was no response from the agents..."
 
         # get the current chat history, add the summary to it
         chat_dicts = state.get(HISTORY_KEY, [])


### PR DESCRIPTION
ATM, the summary variable can go unset and throw an exception causing an infinite loop of deque pop errors. Im not sure these are the right sources for the variable, obv, but it prevents the exception.