### PR TITLE
Detect nested workflows

### DIFF
--- a/llama_agents/deploy/deploy.py
+++ b/llama_agents/deploy/deploy.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, Optional
 from llama_index.core.workflow import Workflow
 
 from llama_agents.control_plane.server import ControlPlaneConfig, ControlPlaneServer
+from llama_agents.deploy.network_workflow import NetworkServiceManager
 from llama_agents.message_queues import (
     BaseMessageQueue,
     KafkaMessageQueue,
@@ -118,6 +119,11 @@ async def deploy_workflow(
     message_queue_config: BaseSettings,
 ) -> None:
     message_queue_client = _get_message_queue_client(message_queue_config)
+
+    # override the service manager, while maintaining dict of existing services
+    workflow._service_manager = NetworkServiceManager(
+        control_plane_config, workflow._service_manager._services
+    )
 
     service = WorkflowService(
         workflow=workflow,

--- a/llama_agents/deploy/network_workflow.py
+++ b/llama_agents/deploy/network_workflow.py
@@ -1,0 +1,73 @@
+from typing import Any, Dict, Optional
+
+from llama_index.core.workflow import Workflow, StopEvent, StartEvent, step
+from llama_index.core.workflow.service import ServiceManager, ServiceNotFoundError
+
+from llama_agents.client.async_client import AsyncLlamaAgentsClient
+from llama_agents.client.sync_client import LlamaAgentsClient
+from llama_agents.control_plane.server import ControlPlaneConfig
+
+
+class NetworkWorkflow(Workflow):
+    def __init__(
+        self,
+        control_plane_config: ControlPlaneConfig,
+        remote_service_name: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.control_plane_config = control_plane_config
+        self.remote_service_name = remote_service_name
+
+    @step
+    async def run_remote_workflow(self, ev: StartEvent) -> StopEvent:
+        client = AsyncLlamaAgentsClient(self.control_plane_config)
+        kwargs = ev.dict()
+
+        session_id = kwargs.pop("session_id", None)
+        if session_id is None:
+            raise ValueError("session_id must be passed in!")
+
+        session = await client.get_session(session_id)
+        result = await session.run(self.remote_service_name, **kwargs)
+
+        return StopEvent(result=result)
+
+
+class NetworkServiceManager(ServiceManager):
+    def __init__(
+        self,
+        control_plane_config: ControlPlaneConfig,
+        existing_services: Dict[str, Workflow],
+    ) -> None:
+        super().__init__()
+        # override with passed in/inherited services
+        self._services = existing_services
+        self.control_plane_config = control_plane_config
+
+    def get(self, name: str, default: Optional["Workflow"] = None) -> "Workflow":
+        try:
+            local_workflow = super().get(name, default=default)
+        except ServiceNotFoundError:
+            local_workflow = None
+
+        # TODO: service manager does not support async
+        client = LlamaAgentsClient(self.control_plane_config)
+        services = client.list_services()
+
+        remote_service = None
+        for service in services:
+            if service.service_name == name:
+                remote_service = service
+                break
+
+        # If the remove service exists, swap it in
+        if remote_service is not None:
+            return NetworkWorkflow(self.control_plane_config, name)
+
+        # else default to the local workflow -- if it exists
+        if local_workflow is None:
+            msg = f"Service {name} not found"
+            raise ServiceNotFoundError(msg)
+
+        return local_workflow

--- a/llama_agents/deploy/network_workflow.py
+++ b/llama_agents/deploy/network_workflow.py
@@ -24,12 +24,9 @@ class NetworkWorkflow(Workflow):
         client = AsyncLlamaAgentsClient(self.control_plane_config)
         kwargs = ev.dict()
 
-        session_id = kwargs.pop("session_id", None)
-        if session_id is None:
-            raise ValueError("session_id must be passed in!")
-
-        session = await client.get_session(session_id)
+        session = await client.create_session()
         result = await session.run(self.remote_service_name, **kwargs)
+        await client.delete_session(session.session_id)
 
         return StopEvent(result=result)
 

--- a/tests/message_queues/test_simple_remote_client.py
+++ b/tests/message_queues/test_simple_remote_client.py
@@ -68,7 +68,9 @@ async def test_remote_client_register_consumer(
     mock_post: MagicMock, message_queue: SimpleMessageQueue, post_side_effect: Callable
 ) -> None:
     # Arrange
-    remote_mq = SimpleRemoteClientMessageQueue(base_url="https://mock-url.io")
+    remote_mq = SimpleRemoteClientMessageQueue(
+        base_url="https://mock-url.io", host=message_queue.host, port=message_queue.port
+    )
     remote_consumer = RemoteMessageConsumer(
         message_type="mock_type", url="remote-consumer.io"
     )
@@ -92,7 +94,9 @@ async def test_remote_client_deregister_consumer(
     mock_post: MagicMock, message_queue: SimpleMessageQueue, post_side_effect: Callable
 ) -> None:
     # Arrange
-    remote_mq = SimpleRemoteClientMessageQueue(base_url="https://mock-url.io")
+    remote_mq = SimpleRemoteClientMessageQueue(
+        base_url="https://mock-url.io", host=message_queue.host, port=message_queue.port
+    )
     remote_consumer = RemoteMessageConsumer(
         message_type="mock_type", url="remote-consumer.io"
     )
@@ -117,7 +121,9 @@ async def test_remote_client_get_consumers(
     mock_get: MagicMock, message_queue: SimpleMessageQueue, get_side_effect: Callable
 ) -> None:
     # Arrange
-    remote_mq = SimpleRemoteClientMessageQueue(base_url="https://mock-url.io")
+    remote_mq = SimpleRemoteClientMessageQueue(
+        base_url="https://mock-url.io", host=message_queue.host, port=message_queue.port
+    )
     remote_consumer = RemoteMessageConsumer(
         message_type="mock_type", url="remote-consumer.io"
     )
@@ -141,7 +147,9 @@ async def test_remote_client_publish(
     # Arrange
     consumer = MockMessageConsumer(message_type="mock_type")
     await message_queue.register_consumer(consumer)
-    remote_mq = SimpleRemoteClientMessageQueue(base_url=message_queue.host)
+    remote_mq = SimpleRemoteClientMessageQueue(
+        base_url=message_queue.host, host=message_queue.host, port=message_queue.port
+    )
     mock_post.side_effect = post_side_effect
 
     # act


### PR DESCRIPTION
This PR adds the ability to detect and deploy nested workflows

It works by highjacking the `ServiceManager` that is inside each workflow. Before injecting the workflow into a step, it optionally checks if that workflow already exists as a service, and then swaps in a new workflow that just makes calls to the remote workflow.

This means users need zero code changes to their existing workflows, they just have to deploy everything, and reap the benefits :) 

---

One concern I had was that the nested workflow always creates (and deletes) a new session. Tbh I wanted to reuse the existing session, but couldn't find a way to insert it. Maybe a future PR :) 

---

Script1 (deploying core services)
```python
from llama_agents import deploy_core, ControlPlaneConfig, SimpleMessageQueueConfig

async def main():
    await deploy_core(
        ControlPlaneConfig(),
        SimpleMessageQueueConfig(),
    )

if __name__ == "__main__":
    import asyncio

    loop = asyncio.get_event_loop()
    loop.run_until_complete(main())
```

Script2 (creating and deploying workflows)
```python
import asyncio
from llama_index.core.workflow import Workflow, StartEvent, StopEvent, step

class InnerWorkflow(Workflow):

    @step()
    async def run_step(self, ev: StartEvent) -> StopEvent:
        arg1 = ev.get("arg1")
        if not arg1:
            raise ValueError("arg1 is required.")

        return StopEvent(result=str(arg1) + "_result")


class OuterWorkflow(Workflow):

    @step()
    async def run_step(self, ev: StartEvent, inner: InnerWorkflow) -> StopEvent:
        arg1 = ev.get("arg1")
        if not arg1:
            raise ValueError("arg1 is required.")
        
        arg1 = await inner.run(arg1=arg1)

        return StopEvent(result=str(arg1) + "_result")


inner = InnerWorkflow()
outer = OuterWorkflow()
outer.add_workflows(inner=InnerWorkflow())


from llama_agents import deploy_workflow, ControlPlaneConfig, WorkflowServiceConfig

async def main():
    inner_task = asyncio.create_task(
        deploy_workflow(
            inner,
            WorkflowServiceConfig(host="127.0.0.1", port=8003, service_name="inner"),
            ControlPlaneConfig(),
        )
    )

    outer_task = asyncio.create_task(
        deploy_workflow(
            outer,
            WorkflowServiceConfig(host="127.0.0.1", port=8002, service_name="outer"),
            ControlPlaneConfig(),
        )
    )

    await asyncio.gather(inner_task, outer_task)

if __name__ == "__main__":
    import asyncio
    
    loop = asyncio.get_event_loop()
    loop.run_until_complete(main())
```

Script3 (using the client)
```python
from llama_agents import LlamaAgentsClient, ControlPlaneConfig

client = LlamaAgentsClient(ControlPlaneConfig())
session = client.create_session()
session.run("outer", arg1="hello_world")
> 'hello_world_result_result'
```