### PR TITLE
Add `external_host` and `external_port` to server settings

### DIFF
--- a/llama_deploy/services/workflow.py
+++ b/llama_deploy/services/workflow.py
@@ -41,6 +41,8 @@ class WorkflowServiceConfig(BaseSettings):
 
     host: str
     port: int
+    external_host: Optional[str] = None
+    external_port: Optional[int] = None
     service_name: str
     description: str = "A service that wraps a llama-index workflow."
     running: bool = True
@@ -107,6 +109,8 @@ class WorkflowService(BaseService):
     step_interval: float = 0.1
     host: Optional[str] = None
     port: Optional[int] = None
+    external_host: Optional[str] = None
+    external_port: Optional[int] = None
     raise_exceptions: bool = False
 
     _message_queue: BaseMessageQueue = PrivateAttr()

--- a/llama_deploy/services/workflow.py
+++ b/llama_deploy/services/workflow.py
@@ -131,6 +131,8 @@ class WorkflowService(BaseService):
         step_interval: float = 0.1,
         host: Optional[str] = None,
         port: Optional[int] = None,
+        external_host: Optional[str] = None,
+        external_port: Optional[int] = None,
         raise_exceptions: bool = False,
     ) -> None:
         super().__init__(
@@ -141,6 +143,8 @@ class WorkflowService(BaseService):
             step_interval=step_interval,
             host=host,
             port=port,
+            external_host=external_host,
+            external_port=external_port,
             raise_exceptions=raise_exceptions,
         )
 
@@ -352,13 +356,14 @@ class WorkflowService(BaseService):
 
     async def launch_server(self) -> None:
         """Launch the service as a FastAPI server."""
-        logger.info(f"Launching {self.service_name} server at {self.host}:{self.port}")
-        # uvicorn.run(self._app, host=self.host, port=self.port)
+        host = self.external_host or self.host
+        port = self.external_port or self.port
+        logger.info(f"Launching {self.service_name} server at {host}:{port}")
 
         class CustomServer(uvicorn.Server):
             def install_signal_handlers(self) -> None:
                 pass
 
-        cfg = uvicorn.Config(self._app, host=self.host, port=self.port)
+        cfg = uvicorn.Config(self._app, host=host, port=port)
         server = CustomServer(cfg)
         await server.serve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "llama-deploy"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = ""
 authors = ["Logan Markewich <logan.markewich@live.com>", "Andrei Fajardo <andrei@runllama.ai>"]
 maintainers = [


### PR DESCRIPTION
This PR adds two optional params that are useful when setting up a system that makes use of a separate internal and external networking (e.g., Docker-Compose and Kubernetes).

- `host` and `port` are used as the default network setting as well as the internal network in more complex settings
- `external_host` and `external_port` are used for outside connections to the service when standing it up (i.e., when invoked via `launch_server()`)