### PR TITLE
[fix] `get_queue_config` biz logic with control plane server

### DIFF
--- a/llama_deploy/control_plane/server.py
+++ b/llama_deploy/control_plane/server.py
@@ -485,8 +485,8 @@ class ControlPlaneServer(BaseControlPlane):
         Returns:
             Dict[str, dict]: A dict of message queue name -> config dict
         """
-        queue_name = self._message_queue.__class__.__name__
-        return {queue_name: self._message_queue.as_config().model_dump()}
+        queue_config = self._message_queue.as_config()
+        return {queue_config.__class__.__name__: queue_config.model_dump()}
 
     async def register_to_message_queue(self) -> StartConsumingCallable:
         return await self.message_queue.register_consumer(self.as_consumer(remote=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "llama-deploy"
-version = "0.1.0b3"
+version = "0.1.0b4"
 description = ""
 authors = ["Logan Markewich <logan.markewich@live.com>", "Andrei Fajardo <andrei@runllama.ai>"]
 maintainers = [


### PR DESCRIPTION
Control plane endpoint for get queue config stores keys as the MessageQueue class name rather than the MessageQueueConfig class name. Downstream processes however use the config class name. This PR fixes this issue. 