### PR TITLE
[fix] external port type

### DIFF
--- a/llama_deploy/message_queues/simple.py
+++ b/llama_deploy/message_queues/simple.py
@@ -38,7 +38,7 @@ class SimpleMessageQueueConfig(BaseSettings):
     host: str = "127.0.0.1"
     port: Optional[int] = 8001
     external_host: Optional[str] = None
-    external_port: Optional[str] = None
+    external_port: Optional[int] = None
 
 
 class SimpleRemoteClientMessageQueue(BaseMessageQueue):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "llama-deploy"
-version = "0.1.0b5"
+version = "0.1.0b6"
 description = ""
 authors = ["Logan Markewich <logan.markewich@live.com>", "Andrei Fajardo <andrei@runllama.ai>"]
 maintainers = [


### PR DESCRIPTION
I mistakenly set the type of `external_port` to `Optional[str]` rather than `Optional[int]`. This PR fixes this mistake.