### PR TITLE
[fix] priority of control plane config url

### DIFF
--- a/llama_deploy/control_plane/server.py
+++ b/llama_deploy/control_plane/server.py
@@ -51,13 +51,10 @@ class ControlPlaneConfig(BaseSettings):
 
     @property
     def url(self) -> str:
-        host = self.internal_host or self.host
-        port = self.internal_port or self.port
-
-        if port:
-            return f"http://{host}:{port}"
+        if self.port:
+            return f"http://{self.host}:{self.port}"
         else:
-            return f"http://{host}"
+            return f"http://{self.host}"
 
 
 class ControlPlaneServer(BaseControlPlane):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "llama-deploy"
-version = "0.1.0b11"
+version = "0.1.0b12"
 description = ""
 authors = ["Logan Markewich <logan.markewich@live.com>", "Andrei Fajardo <andrei@runllama.ai>"]
 maintainers = [


### PR DESCRIPTION
This PR sets the priority of `ControlPlaneConfig.url` to use the `host` and `port` by default.