### PR TITLE
[fix] LlamaDeployClient and async version don't allow for null port of ControlPlane

### DIFF
--- a/llama_deploy/client/async_client.py
+++ b/llama_deploy/client/async_client.py
@@ -113,11 +113,7 @@ class AsyncLlamaDeployClient:
     ):
         self.control_plane_config = control_plane_config
         # TODO: add scheme to config (http, https, ..)
-        self.control_plane_url = (
-            f"http://{control_plane_config.host}:{control_plane_config.port}"
-            if control_plane_config.port
-            else f"http://{control_plane_config.host}"
-        )
+        self.control_plane_url = control_plane_config.url
         self.timeout = timeout
 
     async def create_session(

--- a/llama_deploy/client/async_client.py
+++ b/llama_deploy/client/async_client.py
@@ -115,6 +115,8 @@ class AsyncLlamaDeployClient:
         # TODO: add scheme to config (http, https, ..)
         self.control_plane_url = (
             f"http://{control_plane_config.host}:{control_plane_config.port}"
+            if control_plane_config.port
+            else f"http://{control_plane_config.host}"
         )
         self.timeout = timeout
 

--- a/llama_deploy/client/sync_client.py
+++ b/llama_deploy/client/sync_client.py
@@ -115,6 +115,8 @@ class LlamaDeployClient:
         # TODO: add scheme to config (http, https, ..)
         self.control_plane_url = (
             f"http://{control_plane_config.host}:{control_plane_config.port}"
+            if control_plane_config.port
+            else f"http://{control_plane_config.host}"
         )
         self.timeout = timeout
 

--- a/llama_deploy/client/sync_client.py
+++ b/llama_deploy/client/sync_client.py
@@ -113,11 +113,7 @@ class LlamaDeployClient:
     ):
         self.control_plane_config = control_plane_config
         # TODO: add scheme to config (http, https, ..)
-        self.control_plane_url = (
-            f"http://{control_plane_config.host}:{control_plane_config.port}"
-            if control_plane_config.port
-            else f"http://{control_plane_config.host}"
-        )
+        self.control_plane_url = control_plane_config.url
         self.timeout = timeout
 
     def create_session(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "llama-deploy"
-version = "0.1.0b20"
+version = "0.1.0b21"
 description = ""
 authors = ["Logan Markewich <logan.markewich@live.com>", "Andrei Fajardo <andrei@runllama.ai>"]
 maintainers = [


### PR DESCRIPTION
If control plane url doesn't have a specified port, it is None, and the client doesn't account for this. This PR addresses this issue.