### PR TITLE
chore/nit: Note style in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,4 +545,7 @@ message_queue_config = (
 message_queue = RabbitMQMessageQueue(**message_queue_config)
 ```
 
-> [!NOTE] > `RabbitMQMessageQueueConfig` can load its params from environment variables.
+<!-- prettier-ignore-start -->
+> [!NOTE]
+> `RabbitMQMessageQueueConfig` can load its params from environment variables.
+<!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -545,4 +545,4 @@ message_queue_config = (
 message_queue = RabbitMQMessageQueue(**message_queue_config)
 ```
 
-NOTE: `RabbitMQMessageQueueConfig` can load its params from environment variables.
+> [!NOTE] > `RabbitMQMessageQueueConfig` can load its params from environment variables.


### PR DESCRIPTION
The final note in the README.md doesn't match the style of the first note:

<img width="884" alt="image" src="https://github.com/user-attachments/assets/ab6b4657-d022-4f79-a352-174bf7db004e">

<img width="884" alt="image" src="https://github.com/user-attachments/assets/3dd07784-731c-402a-b4a0-3d67662b90b6">

This PR fixes the second note to match the first note's style.