### PR TITLE
Fix code examples in README.md and docs index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ async def main():
     )
 
 
-if name == "main":
+if __name__ == "__main__":
     import asyncio
 
     asyncio.run(main())
@@ -80,7 +80,6 @@ This will set up the basic infrastructure for your `llama_deploy` system. You ca
 To deploy a workflow as a service, you can use the `deploy_workflow` function:
 
 ```python
-python
 from llama_deploy import (
     deploy_workflow,
     WorkflowServiceConfig,
@@ -110,7 +109,7 @@ async def main():
     )
 
 
-if name == "main":
+if __name__ == "__main__":
     import asyncio
 
     asyncio.run(main())
@@ -123,7 +122,7 @@ This will deploy your workflow as a service within the `llama_deploy` system, an
 Once deployed, you can interact with your deployment using a client.
 
 ```python
-from llama_deploy import LlamaDeployClient
+from llama_deploy import LlamaDeployClient, ControlPlaneConfig
 
 # points to deployed control plane
 client = LlamaDeployClient(ControlPlaneConfig())
@@ -211,7 +210,7 @@ async def main():
     await asyncio.gather(inner_task, outer_task)
 
 
-if name == "main":
+if __name__ == "__main__":
     import asyncio
 
     asyncio.run(main())

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -53,7 +53,7 @@ async def main():
     )
 
 
-if name == "main":
+if __name__ == "__main__":
     import asyncio
 
     asyncio.run(main())
@@ -66,7 +66,6 @@ This will set up the basic infrastructure for your `llama_deploy` system. You ca
 To deploy a workflow as a service, you can use the `deploy_workflow` function:
 
 ```python
-python
 from llama_deploy import (
     deploy_workflow,
     WorkflowServiceConfig,
@@ -96,7 +95,7 @@ async def main():
     )
 
 
-if name == "main":
+if __name__ == "__main__":
     import asyncio
 
     asyncio.run(main())
@@ -109,7 +108,7 @@ This will deploy your workflow as a service within the `llama_deploy` system, an
 Once deployed, you can interact with your deployment using a client.
 
 ```python
-from llama_deploy import LlamaDeployClient
+from llama_deploy import LlamaDeployClient, ControlPlaneConfig
 
 # points to deployed control plane
 client = LlamaDeployClient(ControlPlaneConfig())
@@ -197,7 +196,7 @@ async def main():
     await asyncio.gather(inner_task, outer_task)
 
 
-if name == "main":
+if __name__ == "__main__":
     import asyncio
 
     asyncio.run(main())

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,7 +8,7 @@ At the top of a `llama_deploy` system is the `control plane`. The control plane 
 
 The overall system layout is pictured below.
 
-![A basic system in llama_deploy](./system_diagram.png)
+![A basic system in llama_deploy](../../system_diagram.png)
 
 ## Wait, where is `llama-agents`?
 


### PR DESCRIPTION
The code examples, as written, in the README.md and index.md did not run which is a frustrating first experience with the framework. This PR has fixes I needed to get the core, workflow and client code examples running.

Also the link to the system_diagram png in the index.md needed updating so I fixed that as well.