### PR TITLE
botocore is missing in requirements of python-fullstack example

### DIFF
--- a/examples/python_fullstack/llama_deploy_app/control_plane/requirements.txt
+++ b/examples/python_fullstack/llama_deploy_app/control_plane/requirements.txt
@@ -1,1 +1,2 @@
 llama-deploy>=0.1.0b20
+botocore==1.35.15

--- a/examples/python_fullstack/llama_deploy_app/frontend/requirements.txt
+++ b/examples/python_fullstack/llama_deploy_app/frontend/requirements.txt
@@ -1,2 +1,3 @@
 llama_deploy>=0.1.0b20
 reflex==0.5.10
+botocore==1.35.15

--- a/examples/python_fullstack/llama_deploy_app/message_queue/requirements.txt
+++ b/examples/python_fullstack/llama_deploy_app/message_queue/requirements.txt
@@ -1,1 +1,2 @@
 llama-deploy>=0.1.0b20
+botocore==1.35.15

--- a/examples/python_fullstack/llama_deploy_app/workflows/requirements.txt
+++ b/examples/python_fullstack/llama_deploy_app/workflows/requirements.txt
@@ -4,3 +4,4 @@ llama-index-vector-stores-qdrant>=0.3.0
 llama-index-llms-openai>=0.2.2
 llama-index-embeddings-openai>=0.2.4
 llama-index-readers-file>=0.2.0
+botocore==1.35.15


### PR DESCRIPTION
botocore is missing in requirements of python-fullstack example added latest version of botocore==1.35.15 in requirements 