### PR TITLE
[Feature] Add aws to `llamaindex/llama-deploy` docker image.

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -25,7 +25,7 @@ target "default" {
         build_image = "${BUILD_IMAGE}"
         dist_image = "${DIST_IMAGE}"
         llama_deploy_version = "${LLAMA_DEPLOY_VERSION}"
-        llama_deploy_extras = "[rabbitmq, kafka, redis]"
+        llama_deploy_extras = "[awssqs, rabbitmq, kafka, redis]"
         entrypoint_script = "entrypoint.py"
     }
     platforms = ["linux/amd64", "linux/arm64"]

--- a/docker/docker-compose-awssqs.yml
+++ b/docker/docker-compose-awssqs.yml
@@ -1,6 +1,6 @@
 services:
   control_plane:
-    image: llamaindex/llama-deploy:local
+    image: llamaindex/llama-deploy:0.1.3
     environment:
       CONTROL_PLANE_HOST: control_plane
       CONTROL_PLANE_PORT: 8000

--- a/docker/docker-compose-awssqs.yml
+++ b/docker/docker-compose-awssqs.yml
@@ -1,0 +1,23 @@
+services:
+  control_plane:
+    image: llamaindex/llama-deploy:local
+    environment:
+      CONTROL_PLANE_HOST: control_plane
+      CONTROL_PLANE_PORT: 8000
+      CONTROL_PLANE_INTERNAL_HOST: 0.0.0.0
+      CONTROL_PLANE_INTERNAL_PORT: 8000
+      MESSAGE_QUEUE_CONFIG: awssqs
+      AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+      AWS_REGION: $AWS_REGION
+      RUN_MESSAGE_QUEUE: false
+    ports:
+      - "8000:8000"
+    volumes:
+      - ~/.aws/credentials:/root/.aws/credentials:ro # load creds from local
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 20s

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -6,9 +6,11 @@ from llama_deploy.message_queues.simple import SimpleMessageQueueConfig
 from llama_deploy.message_queues.apache_kafka import KafkaMessageQueueConfig
 from llama_deploy.message_queues.rabbitmq import RabbitMQMessageQueueConfig
 from llama_deploy.message_queues.redis import RedisMessageQueueConfig
+from llama_deploy.message_queues.aws import AWSMessageQueueConfig
 
 
 CONFIGS = {
+    "awssqs": AWSMessageQueueConfig(),
     "kafka": KafkaMessageQueueConfig(),
     "rabbitmq": RabbitMQMessageQueueConfig(),
     "redis": RedisMessageQueueConfig(),


### PR DESCRIPTION
This PR adds the new `AWSMessageQueue` as one of the message queue options in our ready-made docker image.

How was it tested:
- I baked the docker image locally
- Modified the fullstack example to make use of the `awssqs` docker-compose.yml and tested the example still works

<img width="863" alt="image" src="https://github.com/user-attachments/assets/1928160e-5d0b-4952-aa5c-0af7d99db4bc">

![image](https://github.com/user-attachments/assets/d3fdcf75-b105-4b98-936d-9364bb5d306c)

![image](https://github.com/user-attachments/assets/e1545fa3-6e1f-47b7-a015-93e35a0242e8)
