### PR TITLE
feat: deployment runtime

### DIFF
--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -1,4 +1,9 @@
+import asyncio
+import importlib
+import sys
+import threading
 from pathlib import Path
+from typing import Any
 
 from llama_deploy import (
     ControlPlaneServer,
@@ -6,24 +11,118 @@ from llama_deploy import (
     SimpleMessageQueueConfig,
     SimpleOrchestratorConfig,
     SimpleOrchestrator,
+    WorkflowService,
+    WorkflowServiceConfig,
 )
 
-from .config_parser import Config
+from .config_parser import Config, SourceType
+from .source_managers import GitSourceManager
 
-DEPLOYMENTS_ROOT = Path(".deployments")
+
+SOURCE_MANAGERS = {SourceType.git: GitSourceManager()}
 
 
 class Deployment:
-    def __init__(self, config: Config) -> None:
+    def __init__(self, *, config: Config, root_path: Path) -> None:
         self._name = config.name
-        self._path: Path = DEPLOYMENTS_ROOT / self._name
+        self._path = root_path / config.name
+        self._thread: threading.Thread | None = None
+        self._workflow_services: list[WorkflowService] = []
 
-        # TODO: make it configurable
-        mq = SimpleMessageQueue(**SimpleMessageQueueConfig().model_dump())
-        mq_client = mq.client
-
+        self._queue = SimpleMessageQueue(**SimpleMessageQueueConfig().model_dump())
         self._control_plane = ControlPlaneServer(
-            mq_client,
+            self._queue.client,
             SimpleOrchestrator(**SimpleOrchestratorConfig().model_dump()),
             **config.control_plane.model_dump(),
         )
+
+        for service_id, service_config in config.services.items():
+            source = service_config.source
+            if source is None:
+                # this is a default service, skip for now
+                # TODO: check the service name is valid and supported
+                # TODO: possibly start the default service if not running already
+                continue
+
+            # Sync the service source
+            destination = self._path / service_id
+            source_manager = SOURCE_MANAGERS[source.type]
+            source_manager.sync(source.name, str(destination.resolve()))
+
+            # FIXME: Momentarily assuming everything is a workflow
+            if service_config.path is None:
+                msg = "path field in service definition must be set"
+                raise ValueError(msg)
+
+            # Search for a workflow instance in the service path
+            pythonpath = destination.parent.resolve()
+            sys.path.append(str(pythonpath))
+            module_name, workflow_name = Path(service_config.path).name.split(":")
+            module = importlib.import_module(module_name)
+            workflow = getattr(module, workflow_name)
+            workflow_config = WorkflowServiceConfig(
+                host="workflow",
+                port=8002,
+                internal_host="0.0.0.0",
+                internal_port=8002,
+                service_name=workflow_name,
+            )
+            self._workflow_services.append(
+                WorkflowService(
+                    workflow=workflow,
+                    message_queue=self._queue.client,
+                    **workflow_config.model_dump(),
+                )
+            )
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def thread(self) -> threading.Thread | None:
+        return self._thread
+
+    def start(self) -> threading.Thread:
+        async def _start() -> None:
+            tasks = []
+            # Core components
+            tasks.append(asyncio.create_task(self._queue.launch_server()))
+            await asyncio.sleep(1)
+            cp_consumer_fn = await self._control_plane.register_to_message_queue()
+            tasks.append(asyncio.create_task(self._control_plane.launch_server()))
+            await asyncio.sleep(1)
+            tasks.append(asyncio.create_task(cp_consumer_fn()))
+            await asyncio.sleep(1)
+            # Services
+            for wfs in self._workflow_services:
+                service_task = asyncio.create_task(wfs.launch_server())
+                tasks.append(service_task)
+                consumer_fn = await wfs.register_to_message_queue()
+                control_plane_url = (
+                    f"http://{self._control_plane.host}:{self._control_plane.port}"
+                )
+                await wfs.register_to_control_plane(control_plane_url)
+                consumer_task = asyncio.create_task(consumer_fn())
+                tasks.append(consumer_task)
+            # Run allthethings
+            await asyncio.gather(*tasks)
+
+        self._thread = threading.Thread(target=asyncio.run, args=(_start(),))
+        self._thread.start()
+        return self._thread
+
+
+class Manager:
+    def __init__(self, deployments_path: Path = Path(".deployments")) -> None:
+        self._deployments: dict[str, Any] = {}
+        self._deployments_path = deployments_path
+
+    def deploy(self, config: Config) -> None:
+        if config.name in self._deployments:
+            msg = f"Deployment already exists: {config.name}"
+            raise ValueError(msg)
+
+        deployment = Deployment(config=config, root_path=self._deployments_path)
+        self._deployments[config.name] = deployment
+        deployment.start().join()

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -55,7 +55,8 @@ class Deployment:
                 raise ValueError(msg)
 
             # Search for a workflow instance in the service path
-            pythonpath = destination.parent.resolve()
+            pythonpath = (destination / service_config.path).parent.resolve()
+            print(pythonpath)
             sys.path.append(str(pythonpath))
             module_name, workflow_name = Path(service_config.path).name.split(":")
             module = importlib.import_module(module_name)

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from llama_deploy import (
+    ControlPlaneServer,
+    SimpleMessageQueue,
+    SimpleMessageQueueConfig,
+    SimpleOrchestratorConfig,
+    SimpleOrchestrator,
+)
+
+from .config_parser import Config
+
+DEPLOYMENTS_ROOT = Path(".deployments")
+
+
+class Deployment:
+    def __init__(self, config: Config) -> None:
+        self._name = config.name
+        self._path: Path = DEPLOYMENTS_ROOT / self._name
+
+        # TODO: make it configurable
+        mq = SimpleMessageQueue(**SimpleMessageQueueConfig().model_dump())
+        mq_client = mq.client
+
+        self._control_plane = ControlPlaneServer(
+            mq_client,
+            SimpleOrchestrator(**SimpleOrchestratorConfig().model_dump()),
+            **config.control_plane.model_dump(),
+        )

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -30,7 +30,7 @@ class Deployment:
     """
 
     def __init__(self, *, config: Config, root_path: Path) -> None:
-        """Creates a Deployment instance
+        """Creates a Deployment instance.
 
         Args:
             config: The configuration object defining this deployment
@@ -49,21 +49,21 @@ class Deployment:
 
     @property
     def name(self) -> str:
-        """Returns the name of this deployment"""
+        """Returns the name of this deployment."""
         return self._name
 
     @property
     def path(self) -> Path:
-        """Returns the absolute path to the root of this deployment"""
+        """Returns the absolute path to the root of this deployment."""
         return self._path.resolve()
 
     @property
     def thread(self) -> threading.Thread | None:
-        """Returns the thread running the asyncio loop for this deployment"""
+        """Returns the thread running the asyncio loop for this deployment."""
         return self._thread
 
     def start(self) -> threading.Thread:
-        """Spawns the thread running the asyncio loop for this deployment"""
+        """Spawns the thread running the asyncio loop for this deployment."""
         self._thread = threading.Thread(target=asyncio.run, args=(self._start(),))
         self._thread.start()
         return self._thread
@@ -100,7 +100,7 @@ class Deployment:
         await asyncio.gather(*tasks)
 
     def _load_services(self, config: Config) -> list[WorkflowService]:
-        """Creates WorkflowService instances according to the configuration object"""
+        """Creates WorkflowService instances according to the configuration object."""
         workflow_services = []
         for service_id, service_config in config.services.items():
             source = service_config.source

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -78,7 +78,7 @@ class Deployment:
         # Core components
         tasks.append(asyncio.create_task(self._queue.launch_server()))
         # the other components need the queue to run in order to start, give the queue some time to start
-        # FIXME: this is very brittle, we should rethink the bootstrap process
+        # FIXME: having to await a magic number of seconds is very brittle, we should rethink the bootstrap process
         await asyncio.sleep(1)
         cp_consumer_fn = await self._control_plane.register_to_message_queue()
         tasks.append(asyncio.create_task(self._control_plane.launch_server()))
@@ -100,7 +100,7 @@ class Deployment:
         await asyncio.gather(*tasks)
 
     def _load_services(self, config: Config) -> list[WorkflowService]:
-        """Create WorkflowService instances according to the configuration object"""
+        """Creates WorkflowService instances according to the configuration object"""
         workflow_services = []
         for service_id, service_config in config.services.items():
             source = service_config.source
@@ -165,7 +165,7 @@ class Manager:
         self._deployments_path = deployments_path
 
     def deploy(self, config: Config) -> None:
-        """Create a Deployment instance and starts the relative runtime.
+        """Creates a Deployment instance and starts the relative runtime.
 
         Args:
             config: The deployment configuration.

--- a/llama_deploy/apiserver/source_managers/__init__.py
+++ b/llama_deploy/apiserver/source_managers/__init__.py
@@ -6,7 +6,13 @@ __all__ = ["GitSourceManager"]
 
 
 class SourceManager(Protocol):
+    """Protocol to be implemented by classes responsible for managing Deployment sources"""
+
     def sync(
         self, source: str, destination: str | None = None
     ) -> None:  # pragma: no cover
-        ...
+        """Fetches resources from `source` so they can be used in a deployment.
+
+        Optionally uses `destination` to store data when this makes sense for the
+        specific source type.
+        """

--- a/llama_deploy/apiserver/source_managers/__init__.py
+++ b/llama_deploy/apiserver/source_managers/__init__.py
@@ -1,0 +1,10 @@
+from typing import Protocol
+
+from .git import GitSourceManager
+
+__all__ = ["GitSourceManager"]
+
+
+class SourceManager(Protocol):
+    def sync(self, source: str, destination: str | None = None) -> None:
+        ...

--- a/llama_deploy/apiserver/source_managers/__init__.py
+++ b/llama_deploy/apiserver/source_managers/__init__.py
@@ -6,7 +6,7 @@ __all__ = ["GitSourceManager"]
 
 
 class SourceManager(Protocol):
-    """Protocol to be implemented by classes responsible for managing Deployment sources"""
+    """Protocol to be implemented by classes responsible for managing Deployment sources."""
 
     def sync(
         self, source: str, destination: str | None = None

--- a/llama_deploy/apiserver/source_managers/__init__.py
+++ b/llama_deploy/apiserver/source_managers/__init__.py
@@ -6,5 +6,7 @@ __all__ = ["GitSourceManager"]
 
 
 class SourceManager(Protocol):
-    def sync(self, source: str, destination: str | None = None) -> None:
+    def sync(
+        self, source: str, destination: str | None = None
+    ) -> None:  # pragma: no cover
         ...

--- a/llama_deploy/apiserver/source_managers/git.py
+++ b/llama_deploy/apiserver/source_managers/git.py
@@ -8,12 +8,19 @@ class GitSourceManager:
         if not destination:
             raise ValueError("Destination cannot be empty")
 
-        kwargs: dict[str, Any] = {}
-        toks = source.split("@")
-        if len(toks) == 2:
-            branch_name = toks[1]
+        url, branch_name = self._parse_source(source)
+        kwargs: dict[str, Any] = {"url": url, "to_path": destination}
+        if branch_name:
             kwargs["multi_options"] = [f"-b {branch_name}", "--single-branch"]
-        kwargs["url"] = toks[0]
-        kwargs["to_path"] = destination
 
         Repo.clone_from(**kwargs)
+
+    @staticmethod
+    def _parse_source(source: str) -> tuple[str, str | None]:
+        branch_name = None
+        toks = source.split("@")
+        url = toks[0]
+        if len(toks) > 1:
+            branch_name = toks[1]
+
+        return url, branch_name

--- a/llama_deploy/apiserver/source_managers/git.py
+++ b/llama_deploy/apiserver/source_managers/git.py
@@ -4,7 +4,16 @@ from git import Repo
 
 
 class GitSourceManager:
+    """A SourceManager specialized for sources of type `git`."""
+
     def sync(self, source: str, destination: str | None = None) -> None:
+        """Clones the repository at URL `source` into a local path `destination`.
+
+        Args:
+            source: The URL of the git repository. It can optionally contain a branch target using the name convention
+                `git_repo_url@branch_name`. For example, "https://example.com/llama_deploy.git@branch_name".
+            destination: The path in the local filesystem where to clone the git repository.
+        """
         if not destination:
             raise ValueError("Destination cannot be empty")
 

--- a/llama_deploy/apiserver/source_managers/git.py
+++ b/llama_deploy/apiserver/source_managers/git.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from git import Repo
+
+
+class GitSourceManager:
+    def sync(self, source: str, destination: str | None = None) -> None:
+        if not destination:
+            raise ValueError("Destination cannot be empty")
+
+        kwargs: dict[str, Any] = {}
+        toks = source.split("@")
+        if len(toks) == 2:
+            branch_name = toks[1]
+            kwargs["multi_options"] = [f"-b {branch_name}", "--single-branch"]
+        kwargs["url"] = toks[0]
+        kwargs["to_path"] = destination
+
+        Repo.clone_from(**kwargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -759,6 +759,38 @@ test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "cloudpickle", "dask", "d
 tqdm = ["tqdm"]
 
 [[package]]
+name = "gitdb"
+version = "4.0.11"
+description = "Git Object Database"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "gitdb-4.0.11-py3-none-any.whl", hash = "sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4"},
+    {file = "gitdb-4.0.11.tar.gz", hash = "sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.43"
+description = "GitPython is a Python library used to interact with Git repositories"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "GitPython-3.1.43-py3-none-any.whl", hash = "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"},
+    {file = "GitPython-3.1.43.tar.gz", hash = "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[package.extras]
+doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinxcontrib-applehelp (>=1.0.2,<=1.0.4)", "sphinxcontrib-devhelp (==1.0.2)", "sphinxcontrib-htmlhelp (>=2.0.0,<=2.0.1)", "sphinxcontrib-qthelp (==1.0.3)", "sphinxcontrib-serializinghtml (==1.1.5)"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
+
+[[package]]
 name = "greenlet"
 version = "3.1.0"
 description = "Lightweight in-process concurrent programming"
@@ -1894,6 +1926,17 @@ files = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.1"
+description = "A pure Python implementation of a sliding window memory map manager"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "smmap-5.0.1-py3-none-any.whl", hash = "sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da"},
+    {file = "smmap-5.0.1.tar.gz", hash = "sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -2796,4 +2839,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<4.0"
-content-hash = "8497977cb8238b62bb09032e838b0ecd46acb51ae489c98bf71dd9fb8c5b3aa2"
+content-hash = "d1770facdd4ceeea02b1c86f0737e8b773028e7a659faec98c7502e3efeb5774"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ aio-pika = {version = "^9.4.2", optional = true}
 kafka-python-ng = {version = "^2.2.2", optional = true}
 redis = {version = "^5.0.7", optional = true}
 types-aiobotocore = {version = "^2.14.0", optional = true, extras = ["sqs", "sns"]}
+gitpython = "^3.1.43"
 
 [tool.poetry.extras]
 kafka = ["aiokafka", "kafka-python-ng"]

--- a/tests/apiserver/conftest.py
+++ b/tests/apiserver/conftest.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def data_path() -> Path:
+    return Path(__file__).parent / "data"

--- a/tests/apiserver/data/git_service.yaml
+++ b/tests/apiserver/data/git_service.yaml
@@ -1,0 +1,11 @@
+name: TestDeployment
+
+control-plane: {}
+
+services:
+  test-workflow:
+    name: Test Workflow
+    source:
+      type: git
+      name: https://github.com/run-llama/llama_deploy.git@massi/deploy
+    path: tests/apiserver/data/workflow:my_workflow

--- a/tests/apiserver/data/workflow/__init__.py
+++ b/tests/apiserver/data/workflow/__init__.py
@@ -1,0 +1,3 @@
+from .workflow_test import MyWorkflow
+
+my_workflow = MyWorkflow()

--- a/tests/apiserver/data/workflow/workflow_test.py
+++ b/tests/apiserver/data/workflow/workflow_test.py
@@ -1,0 +1,7 @@
+from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
+
+
+class MyWorkflow(Workflow):
+    @step
+    def do_something(self, ctx: Context, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="Done.")

--- a/tests/apiserver/source_managers/test_git.py
+++ b/tests/apiserver/source_managers/test_git.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+import pytest
+
+from llama_deploy.apiserver.source_managers.git import GitSourceManager
+
+
+def test_parse_source() -> None:
+    sm = GitSourceManager()
+    assert sm._parse_source("https://example.com/llama_deploy.git@branch_name") == (
+        "https://example.com/llama_deploy.git",
+        "branch_name",
+    )
+    assert sm._parse_source("https://example.com/llama_deploy.git") == (
+        "https://example.com/llama_deploy.git",
+        None,
+    )
+
+
+def test_sync_wrong_params() -> None:
+    sm = GitSourceManager()
+    with pytest.raises(ValueError, match="Destination cannot be empty"):
+        sm.sync("some_source")
+
+
+def test_sync() -> None:
+    sm = GitSourceManager()
+    with mock.patch("llama_deploy.apiserver.source_managers.git.Repo") as repo_mock:
+        sm.sync("source", "dest")
+        repo_mock.clone_from.assert_called_with(to_path="dest", url="source")
+        sm.sync("source@branch", "dest")
+        repo_mock.clone_from.assert_called_with(
+            to_path="dest", url="source", multi_options=["-b branch", "--single-branch"]
+        )

--- a/tests/apiserver/test_config_parser.py
+++ b/tests/apiserver/test_config_parser.py
@@ -1,13 +1,6 @@
 from pathlib import Path
 
-import pytest
-
 from llama_deploy.apiserver.config_parser import Config
-
-
-@pytest.fixture
-def data_path() -> Path:
-    return Path(__file__).parent / "data"
 
 
 def test_load_config_file(data_path: Path) -> None:

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from llama_deploy.apiserver.config_parser import Config
+from llama_deploy.apiserver.deployment import Manager
+
+
+def test_deploy_git(data_path: Path, tmp_path: Path) -> None:
+    config = Config.from_yaml(data_path / "git_service.yaml")
+    manager = Manager(tmp_path)
+    manager.deploy(config)
+    print(tmp_path)

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -1,11 +1,51 @@
+from copy import deepcopy
 from pathlib import Path
+from unittest import mock
+
+import pytest
 
 from llama_deploy.apiserver.config_parser import Config
-from llama_deploy.apiserver.deployment import Manager
+from llama_deploy.apiserver.deployment import Deployment
+from llama_deploy.message_queues import SimpleMessageQueue
+from llama_deploy.control_plane import ControlPlaneServer
+
+# def test_deploy_git(data_path: Path, tmp_path: Path) -> None:
+#     print(tmp_path)
+#     config = Config.from_yaml(data_path / "git_service.yaml")
+#     manager = Manager(tmp_path)
+#     manager.deploy(config)
 
 
-def test_deploy_git(data_path: Path, tmp_path: Path) -> None:
-    print(tmp_path)
+def test_deploy_ctor(data_path: Path) -> None:
     config = Config.from_yaml(data_path / "git_service.yaml")
-    manager = Manager(tmp_path)
-    manager.deploy(config)
+    with mock.patch("llama_deploy.apiserver.deployment.SOURCE_MANAGERS") as sm_dict:
+        sm_dict["git"] = mock.MagicMock()
+        d = Deployment(config=config, root_path=Path("."))
+
+        sm_dict["git"].sync.assert_called_once()
+        assert d.name == "TestDeployment"
+        assert str(d.path) == "TestDeployment"
+        assert d.thread is None
+        assert type(d._queue) is SimpleMessageQueue
+        assert type(d._control_plane) is ControlPlaneServer
+        assert len(d._workflow_services) == 1
+
+
+def test_deploy_ctor_malformed_config(data_path: Path) -> None:
+    config = Config.from_yaml(data_path / "git_service.yaml")
+    config.services["test-workflow"].path = None
+    with pytest.raises(
+        ValueError, match="path field in service definition must be set"
+    ):
+        Deployment(config=config, root_path=Path("."))
+
+
+def test_deploy_ctor_skip_default_service(data_path: Path) -> None:
+    config = Config.from_yaml(data_path / "git_service.yaml")
+    config.services["test-workflow2"] = deepcopy(config.services["test-workflow"])
+    config.services["test-workflow2"].source = None
+
+    with mock.patch("llama_deploy.apiserver.deployment.SOURCE_MANAGERS") as sm_dict:
+        sm_dict["git"] = mock.MagicMock()
+        d = Deployment(config=config, root_path=Path("."))
+        assert len(d._workflow_services) == 1

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -5,7 +5,7 @@ from llama_deploy.apiserver.deployment import Manager
 
 
 def test_deploy_git(data_path: Path, tmp_path: Path) -> None:
+    print(tmp_path)
     config = Config.from_yaml(data_path / "git_service.yaml")
     manager = Manager(tmp_path)
     manager.deploy(config)
-    print(tmp_path)

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -18,7 +18,7 @@ def test_deployment_ctor(data_path: Path) -> None:
 
         sm_dict["git"].sync.assert_called_once()
         assert d.name == "TestDeployment"
-        assert str(d.path) == "TestDeployment"
+        assert d.path.name == "TestDeployment"
         assert d.thread is None
         assert type(d._queue) is SimpleMessageQueue
         assert type(d._control_plane) is ControlPlaneServer


### PR DESCRIPTION
This PR implements the concept of "deployment" that was introduced along with the "apiserver" in #259 

Overview of the abstractions introduced:
- `Deployment`: runs the control plane, the message queue and spawns the services defined in the configuration file
- `Manager`: orchestrate multiple deployment instances
- `SourceManager`: a family of components responsible for managing sources (docker/git) for each deployment
- `GitSourceManager`: a concrete implementation of `SourceManager` specialized for dealing with git sources

Known limitations:
- See the `TODO` and `FIXME` in code comments for the details
- The message queue type is hardcoded, will be made configurable eventually
- Several places in the code assume that all the services are "workflow services"

Next steps:
- Create a thread pool to manage all the concurrent threads runnning different deployments
- Introduce a HTTP-based API for the manager to expose its Python api to clients and CLIs