### PR TITLE
feat: use a thread pool to orchestrate deployments

### DIFF
--- a/tests/apiserver/data/git_service.yaml
+++ b/tests/apiserver/data/git_service.yaml
@@ -7,5 +7,5 @@ services:
     name: Test Workflow
     source:
       type: git
-      name: https://github.com/run-llama/llama_deploy.git@massi/deploy
+      name: https://github.com/run-llama/llama_deploy.git
     path: tests/apiserver/data/workflow:my_workflow

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -20,7 +20,6 @@ def test_deployment_ctor(data_path: Path) -> None:
         sm_dict["git"].sync.assert_called_once()
         assert d.name == "TestDeployment"
         assert d.path.name == "TestDeployment"
-        assert d.thread is None
         assert type(d._queue) is SimpleMessageQueue
         assert type(d._control_plane) is ControlPlaneServer
         assert len(d._workflow_services) == 1
@@ -44,17 +43,6 @@ def test_deployment_ctor_skip_default_service(data_path: Path) -> None:
         sm_dict["git"] = mock.MagicMock()
         d = Deployment(config=config, root_path=Path("."))
         assert len(d._workflow_services) == 1
-
-
-@pytest.mark.asyncio()
-async def test_deployment_start(data_path: Path) -> None:
-    config = Config.from_yaml(data_path / "git_service.yaml")
-    with mock.patch("llama_deploy.apiserver.deployment.SOURCE_MANAGERS") as sm_dict:
-        sm_dict["git"] = mock.MagicMock()
-        d = Deployment(config=config, root_path=Path("."))
-        d._start = mock.AsyncMock()  # type: ignore
-        d.start()
-        d._start.assert_called_once()
 
 
 def test_manager_ctor() -> None:


### PR DESCRIPTION
Instead of manually managing threads for each deployment, we use a `ThreadPool` to do that.

Notes for the reviewer:
- The responsibility of spawning the thread to accomodate the asyncio loop was removed from the `Deployment` class, that now is only responsible for implementing the `start` task
- The thread pool has a fixed size, I took the chance to reflect this into the manager API with the `max_deployments` parameter because it makes sense to cap the number of deployments.
- The manager has now a `serve` method that runs forever to keep the thread pool alive indefinitely

Usage exampe of this version of the manager:
```
manager = Manager(tmp_path)

# Run in the background, we use threads here but it could be a different process
t = threading.Thread(target=asyncio.run, args=(manager.serve(),))
t.start()

# While the manager is running it accepts new deployments
manager.deploy(config1)
manager.deploy(config2)

# Block until CTRL+C
t.join()
```
