### PR TITLE
feat: Allow configuration of the message queue in the deployment config file

### DIFF
--- a/llama_deploy/apiserver/config_parser.py
+++ b/llama_deploy/apiserver/config_parser.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import Self, Annotated, Union, Literal
+from typing import Self, Annotated, Union
 
 import yaml
 from pydantic import BaseModel, Field
@@ -15,40 +15,15 @@ from llama_deploy.message_queues import (
 )
 
 
-class MessageQueueConfigAWS(BaseModel):
-    queue_type: Literal["aws"] = Field("aws", alias="queue-type")
-    config: AWSMessageQueueConfig
-
-
-class MessageQueueConfigKafka(BaseModel):
-    queue_type: Literal["kafka"] = Field("kafka", alias="queue-type")
-    config: KafkaMessageQueueConfig
-
-
-class MessageQueueConfigRabbitMQ(BaseModel):
-    queue_type: Literal["rabbitmq"] = Field("rabbitmq", alias="queue-type")
-    config: RabbitMQMessageQueueConfig
-
-
-class MessageQueueConfigRedis(BaseModel):
-    queue_type: Literal["redis"] = Field("redis", alias="queue-type")
-    config: RedisMessageQueueConfig
-
-
-class MessageQueueConfigSimple(BaseModel):
-    queue_type: Literal["simple"] = Field("simple", alias="queue-type")
-    config: SimpleMessageQueueConfig
-
-
 MessageQueueConfig = Annotated[
     Union[
-        MessageQueueConfigAWS,
-        MessageQueueConfigKafka,
-        MessageQueueConfigRabbitMQ,
-        MessageQueueConfigRedis,
-        MessageQueueConfigSimple,
+        AWSMessageQueueConfig,
+        KafkaMessageQueueConfig,
+        RabbitMQMessageQueueConfig,
+        RedisMessageQueueConfig,
+        SimpleMessageQueueConfig,
     ],
-    Field(discriminator="queue_type"),
+    Field(discriminator="type"),
 ]
 
 

--- a/llama_deploy/apiserver/config_parser.py
+++ b/llama_deploy/apiserver/config_parser.py
@@ -1,15 +1,45 @@
 from enum import Enum
 from pathlib import Path
-from typing import Self
+from typing import Self, TypeAlias
 
 import yaml
 from pydantic import BaseModel, Field
 
 from llama_deploy.control_plane.server import ControlPlaneConfig
+from llama_deploy.message_queues import (
+    AWSMessageQueueConfig,
+    KafkaMessageQueueConfig,
+    RedisMessageQueueConfig,
+    SimpleMessageQueueConfig,
+    RabbitMQMessageQueueConfig,
+)
+
+MessageQueueConfigType: TypeAlias = (
+    AWSMessageQueueConfig
+    | KafkaMessageQueueConfig
+    | RedisMessageQueueConfig
+    | SimpleMessageQueueConfig
+    | RabbitMQMessageQueueConfig
+)
+
+
+class MessageQueueType(str, Enum):
+    """Supported types of message queues"""
+
+    aws = "aws"
+    kafka = "kafka"
+    redis = "redis"
+    simple = "simple"
+    rabbit = "rabbit"
+
+
+class MessageQueueConfig(BaseModel):
+    type: MessageQueueType
+    config: MessageQueueConfigType
 
 
 class SourceType(str, Enum):
-    """Supported types for the `source parameter."""
+    """Supported types for the `Service.source` parameter."""
 
     git = "git"
     docker = "docker"
@@ -38,6 +68,7 @@ class Config(BaseModel):
 
     name: str
     control_plane: ControlPlaneConfig = Field(alias="control-plane")
+    message_queue: MessageQueueConfig = Field(alias="message-queue")
     services: dict[str, Service]
 
     @classmethod

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -164,7 +164,13 @@ class Deployment:
     def _load_message_queue(self, cfg: MessageQueueConfig | None) -> BaseMessageQueue:
         # Use the SimpleMessageQueue as the default
         if cfg is None:
-            cfg = MessageQueueConfigSimple(config=SimpleMessageQueueConfig())
+            # we use model_validate instead of __init__ to avoid static checkers complaining over field aliases
+            cfg = MessageQueueConfigSimple.model_validate(
+                {
+                    "queue-type": "simple",
+                    "config": SimpleMessageQueueConfig(),
+                }
+            )
 
         if cfg.queue_type == "aws":
             return AWSMessageQueue(**cfg.model_dump())

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -50,7 +50,8 @@ class Deployment:
         """
         self._name = config.name
         self._path = root_path / config.name
-        self._queue = SimpleMessageQueue(**SimpleMessageQueueConfig().model_dump())
+        self._simple_message_queue_task: SimpleMessageQueue | None = None
+        self._queue = self._load_message_queue(config.message_queue)
         self._control_plane = ControlPlaneServer(
             self._queue,
             SimpleOrchestrator(**SimpleOrchestratorConfig().model_dump()),

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -8,14 +8,14 @@ from typing import Any
 from llama_deploy import (
     ControlPlaneServer,
     SimpleMessageQueue,
-    SimpleMessageQueueConfig,
     SimpleOrchestratorConfig,
     SimpleOrchestrator,
     WorkflowService,
     WorkflowServiceConfig,
 )
+from llama_deploy.message_queues import BaseMessageQueue
 
-from .config_parser import Config, SourceType
+from .config_parser import Config, SourceType, MessageQueueType, MessageQueueConfig
 from .source_managers import GitSourceManager
 
 
@@ -39,9 +39,10 @@ class Deployment:
         self._name = config.name
         self._path = root_path / config.name
         self._thread: threading.Thread | None = None
-        self._queue = SimpleMessageQueue(**SimpleMessageQueueConfig().model_dump())
+        self._simple_message_queue_task: SimpleMessageQueue | None = None
+        self._queue = self._load_message_queue(config.message_queue)
         self._control_plane = ControlPlaneServer(
-            self._queue.client,
+            self._queue,
             SimpleOrchestrator(**SimpleOrchestratorConfig().model_dump()),
             **config.control_plane.model_dump(),
         )
@@ -75,11 +76,16 @@ class Deployment:
         All the tasks are gathered before returning.
         """
         tasks = []
-        # Core components
-        tasks.append(asyncio.create_task(self._queue.launch_server()))
-        # the other components need the queue to run in order to start, give the queue some time to start
-        # FIXME: having to await a magic number of seconds is very brittle, we should rethink the bootstrap process
-        await asyncio.sleep(1)
+
+        # Spawn SimpleMessageQueue if needed
+        if self._simple_message_queue_task:
+            # If SimpleMessageQueue was selected in the config file we take care of running the task
+            tasks.append(asyncio.create_task(self._queue.launch_server()))
+            # the other components need the queue to run in order to start, give the queue some time to start
+            # FIXME: having to await a magic number of seconds is very brittle, we should rethink the bootstrap process
+            await asyncio.sleep(1)
+
+        # Control Plane
         cp_consumer_fn = await self._control_plane.register_to_message_queue()
         tasks.append(asyncio.create_task(self._control_plane.launch_server()))
         tasks.append(asyncio.create_task(cp_consumer_fn()))
@@ -142,6 +148,24 @@ class Deployment:
             )
 
         return workflow_services
+
+    def _load_message_queue(self, cfg: MessageQueueConfig) -> BaseMessageQueue:
+        # if cfg.type == MessageQueueType.aws:
+        #     pass
+        # elif cfg.type == MessageQueueType.kafka:
+        #     pass
+        # elif cfg.type == MessageQueueType.rabbit:
+        #     pass
+        # elif cfg.type == MessageQueueType.redis:
+        #     pass
+        if cfg.type == MessageQueueType.simple:
+            self._simple_message_queue_task = SimpleMessageQueue(
+                cfg.config.model_dump()
+            )
+            return self._simple_message_queue_task.client
+        else:
+            msg = f"Unsupported message queue: {cfg.type}"
+            raise ValueError(msg)
 
 
 class Manager:

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -25,7 +25,6 @@ from llama_deploy.message_queues import (
 from .config_parser import (
     Config,
     SourceType,
-    MessageQueueConfigSimple,
     MessageQueueConfig,
 )
 from .source_managers import GitSourceManager
@@ -153,28 +152,21 @@ class Deployment:
         # Use the SimpleMessageQueue as the default
         if cfg is None:
             # we use model_validate instead of __init__ to avoid static checkers complaining over field aliases
-            cfg = MessageQueueConfigSimple.model_validate(
-                {
-                    "queue-type": "simple",
-                    "config": SimpleMessageQueueConfig(),
-                }
-            )
+            cfg = SimpleMessageQueueConfig()
 
-        if cfg.queue_type == "aws":
+        if cfg.type == "aws":
             return AWSMessageQueue(**cfg.model_dump())
-        elif cfg.queue_type == "kafka":
+        elif cfg.type == "kafka":
             return KafkaMessageQueue(**cfg.model_dump())
-        elif cfg.queue_type == "rabbitmq":
+        elif cfg.type == "rabbitmq":
             return RabbitMQMessageQueue(**cfg.model_dump())
-        elif cfg.queue_type == "redis":
+        elif cfg.type == "redis":
             return RedisMessageQueue(**cfg.model_dump())
-        elif cfg.queue_type == "simple":
-            self._simple_message_queue_task = SimpleMessageQueue(
-                **cfg.config.model_dump()
-            )
+        elif cfg.type == "simple":
+            self._simple_message_queue_task = SimpleMessageQueue(**cfg.model_dump())
             return self._simple_message_queue_task.client
         else:
-            msg = f"Unsupported message queue: {cfg.queue_type}"
+            msg = f"Unsupported message queue: {cfg.type}"
             raise ValueError(msg)
 
 

--- a/llama_deploy/message_queues/apache_kafka.py
+++ b/llama_deploy/message_queues/apache_kafka.py
@@ -3,16 +3,14 @@
 import asyncio
 import json
 from logging import getLogger
-from pydantic import BaseModel, model_validator
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Literal
+
+from pydantic import BaseModel, model_validator, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing import Any, Callable, Coroutine, Dict, List, Optional
+
 from llama_deploy.message_consumers.callable import CallableMessageConsumer
-from llama_deploy.message_queues.base import (
-    BaseMessageQueue,
-)
-from llama_deploy.message_consumers.base import (
-    BaseMessageQueueConsumer,
-)
+from llama_deploy.message_queues.base import BaseMessageQueue
+from llama_deploy.message_consumers.base import BaseMessageQueueConsumer
 from llama_deploy.messages.base import QueueMessage
 
 import logging
@@ -32,6 +30,7 @@ class KafkaMessageQueueConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="KAFKA_")
 
+    type: Literal["kafka"] = Field(default="kafka", exclude=True)
     url: str = DEFAULT_URL
     host: Optional[str] = None
     port: Optional[int] = None

--- a/llama_deploy/message_queues/aws.py
+++ b/llama_deploy/message_queues/aws.py
@@ -3,7 +3,8 @@
 import asyncio
 import json
 from logging import getLogger
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Literal
+
 from pydantic import BaseModel, PrivateAttr, SecretStr, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -47,6 +48,7 @@ class AWSMessageQueueConfig(BaseSettings):
 
     model_config = SettingsConfigDict()
 
+    type: Literal["aws"] = Field(default="aws", exclude=True)
     aws_region: str
     aws_access_key_id: Optional[str] = Field(default=None, exclude=True)
     aws_secret_access_key: Optional[str] = Field(default=None, exclude=True)

--- a/llama_deploy/message_queues/rabbitmq.py
+++ b/llama_deploy/message_queues/rabbitmq.py
@@ -3,9 +3,11 @@
 import asyncio
 import json
 from logging import getLogger
-from pydantic import BaseModel
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
 from llama_deploy.message_queues.base import (
     BaseMessageQueue,
 )
@@ -30,6 +32,7 @@ class RabbitMQMessageQueueConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="RABBITMQ_")
 
+    type: Literal["rabbitmq"] = Field(default="rabbitmq", exclude=True)
     url: str = DEFAULT_URL
     exchange_name: str = DEFAULT_EXCHANGE_NAME
     username: Optional[str] = None

--- a/llama_deploy/message_queues/redis.py
+++ b/llama_deploy/message_queues/redis.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import json
-from pydantic import PrivateAttr, BaseModel
-from pydantic_settings import BaseSettings, SettingsConfigDict
 from logging import getLogger
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Literal
+
+from pydantic import PrivateAttr, BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
 from llama_deploy.message_queues.base import BaseMessageQueue
 from llama_deploy.messages.base import QueueMessage
 from llama_deploy.message_consumers.base import (
@@ -26,6 +28,7 @@ class RedisMessageQueueConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="REDIS_")
 
+    type: Literal["redis"] = Field(default="redis", exclude=True)
     url: str = DEFAULT_URL
     host: Optional[str] = None
     port: Optional[int] = None

--- a/llama_deploy/message_queues/simple.py
+++ b/llama_deploy/message_queues/simple.py
@@ -4,15 +4,15 @@ import asyncio
 import httpx
 import random
 import uvicorn
-
 from collections import deque
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, HTTPException, status
 from logging import getLogger
+from typing import Any, AsyncGenerator, Dict, List, Optional, Literal
+from urllib.parse import urljoin
+
+from fastapi import FastAPI, HTTPException, status
 from pydantic import BaseModel, Field, PrivateAttr
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing import Any, AsyncGenerator, Dict, List, Optional
-from urllib.parse import urljoin
 
 from llama_deploy.message_queues.base import BaseMessageQueue
 from llama_deploy.messages.base import QueueMessage
@@ -35,6 +35,7 @@ class SimpleMessageQueueConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="SIMPLE_MESSAGE_QUEUE_")
 
+    type: Literal["simple"] = Field(default="simple", exclude=True)
     host: str = "127.0.0.1"
     port: Optional[int] = 8001
     internal_host: Optional[str] = None

--- a/tests/apiserver/conftest.py
+++ b/tests/apiserver/conftest.py
@@ -1,8 +1,22 @@
 from pathlib import Path
+from typing import Iterator
+from unittest import mock
 
 import pytest
+
+
+from llama_deploy.apiserver.deployment import Deployment
+from llama_deploy.apiserver.config_parser import Config
 
 
 @pytest.fixture
 def data_path() -> Path:
     return Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def mocked_deployment(data_path: Path) -> Iterator[Deployment]:
+    config = Config.from_yaml(data_path / "git_service.yaml")
+    with mock.patch("llama_deploy.apiserver.deployment.SOURCE_MANAGERS") as sm_dict:
+        sm_dict["git"] = mock.MagicMock()
+        yield Deployment(config=config, root_path=Path("."))

--- a/tests/apiserver/data/example.yaml
+++ b/tests/apiserver/data/example.yaml
@@ -4,10 +4,9 @@ control-plane:
   port: 8000
 
 message-queue:
-  queue-type: simple
-  config:
-    host: "127.0.0.1"
-    port: 8001
+  type: simple
+  host: "127.0.0.1"
+  port: 8001
 
 services:
   myworkflow:

--- a/tests/apiserver/data/example.yaml
+++ b/tests/apiserver/data/example.yaml
@@ -3,6 +3,12 @@ name: MyDeployment
 control-plane:
   port: 8000
 
+message-queue:
+  queue-type: simple
+  config:
+    host: "127.0.0.1"
+    port: 8001
+
 services:
   myworkflow:
     # A python workflow available in a git repo

--- a/tests/apiserver/test_config_parser.py
+++ b/tests/apiserver/test_config_parser.py
@@ -9,6 +9,9 @@ def test_load_config_file(data_path: Path) -> None:
 
     assert config.control_plane.port == 8000
 
+    assert config.message_queue is not None
+    assert config.message_queue.queue_type == "simple"
+
     wf_config = config.services["myworkflow"]
     assert wf_config.name == "My Python Workflow"
     assert wf_config.source

--- a/tests/apiserver/test_config_parser.py
+++ b/tests/apiserver/test_config_parser.py
@@ -10,7 +10,7 @@ def test_load_config_file(data_path: Path) -> None:
     assert config.control_plane.port == 8000
 
     assert config.message_queue is not None
-    assert config.message_queue.queue_type == "simple"
+    assert config.message_queue.type == "simple"
 
     wf_config = config.services["myworkflow"]
     assert wf_config.name == "My Python Workflow"

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -66,25 +66,25 @@ def test_deployment___load_message_queue_not_supported(
 
 def test_deployment__load_message_queues(mocked_deployment: Deployment) -> None:
     with mock.patch("llama_deploy.apiserver.deployment.AWSMessageQueue") as m:
-        mocked_config = mock.MagicMock(queue_type="aws")
+        mocked_config = mock.MagicMock(type="aws")
         mocked_config.model_dump.return_value = {"foo": "aws"}
         mocked_deployment._load_message_queue(mocked_config)
         m.assert_called_with(**{"foo": "aws"})
 
     with mock.patch("llama_deploy.apiserver.deployment.KafkaMessageQueue") as m:
-        mocked_config = mock.MagicMock(queue_type="kafka")
+        mocked_config = mock.MagicMock(type="kafka")
         mocked_config.model_dump.return_value = {"foo": "kafka"}
         mocked_deployment._load_message_queue(mocked_config)
         m.assert_called_with(**{"foo": "kafka"})
 
     with mock.patch("llama_deploy.apiserver.deployment.RabbitMQMessageQueue") as m:
-        mocked_config = mock.MagicMock(queue_type="rabbitmq")
+        mocked_config = mock.MagicMock(type="rabbitmq")
         mocked_config.model_dump.return_value = {"foo": "rabbitmq"}
         mocked_deployment._load_message_queue(mocked_config)
         m.assert_called_with(**{"foo": "rabbitmq"})
 
     with mock.patch("llama_deploy.apiserver.deployment.RedisMessageQueue") as m:
-        mocked_config = mock.MagicMock(queue_type="redis")
+        mocked_config = mock.MagicMock(type="redis")
         mocked_config.model_dump.return_value = {"foo": "redis"}
         mocked_deployment._load_message_queue(mocked_config)
         m.assert_called_with(**{"foo": "redis"})

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -4,9 +4,14 @@ from unittest import mock
 
 import pytest
 
-from llama_deploy.apiserver.config_parser import Config
+from llama_deploy.apiserver.config_parser import (
+    Config,
+)
 from llama_deploy.apiserver.deployment import Deployment, Manager
 from llama_deploy.control_plane import ControlPlaneServer
+from llama_deploy.message_queues import (
+    SimpleRemoteClientMessageQueue,
+)
 
 
 def test_deployment_ctor(data_path: Path) -> None:
@@ -45,14 +50,51 @@ def test_deployment_ctor_skip_default_service(data_path: Path) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_deployment_start(data_path: Path) -> None:
-    config = Config.from_yaml(data_path / "git_service.yaml")
-    with mock.patch("llama_deploy.apiserver.deployment.SOURCE_MANAGERS") as sm_dict:
-        sm_dict["git"] = mock.MagicMock()
-        d = Deployment(config=config, root_path=Path("."))
-        d._start = mock.AsyncMock()  # type: ignore
-        d.start()
-        d._start.assert_called_once()
+async def test_deployment_start(mocked_deployment: Deployment) -> None:
+    mocked_deployment._start = mock.AsyncMock()  # type: ignore
+    mocked_deployment.start()
+    mocked_deployment._start.assert_called_once()
+
+
+def test_deployment___load_message_queue_default(mocked_deployment: Deployment) -> None:
+    q = mocked_deployment._load_message_queue(None)
+    assert type(q) is SimpleRemoteClientMessageQueue
+    assert q.port == 8001
+    assert q.host == "127.0.0.1"
+
+
+def test_deployment___load_message_queue_not_supported(
+    mocked_deployment: Deployment,
+) -> None:
+    mocked_config = mock.MagicMock(queue_type="does_not_exist")
+    with pytest.raises(ValueError, match="Unsupported message queue:"):
+        mocked_deployment._load_message_queue(mocked_config)
+
+
+def test_deployment__load_message_queues(mocked_deployment: Deployment) -> None:
+    with mock.patch("llama_deploy.apiserver.deployment.AWSMessageQueue") as m:
+        mocked_config = mock.MagicMock(queue_type="aws")
+        mocked_config.model_dump.return_value = {"foo": "aws"}
+        mocked_deployment._load_message_queue(mocked_config)
+        m.assert_called_with(**{"foo": "aws"})
+
+    with mock.patch("llama_deploy.apiserver.deployment.KafkaMessageQueue") as m:
+        mocked_config = mock.MagicMock(queue_type="kafka")
+        mocked_config.model_dump.return_value = {"foo": "kafka"}
+        mocked_deployment._load_message_queue(mocked_config)
+        m.assert_called_with(**{"foo": "kafka"})
+
+    with mock.patch("llama_deploy.apiserver.deployment.RabbitMQMessageQueue") as m:
+        mocked_config = mock.MagicMock(queue_type="rabbitmq")
+        mocked_config.model_dump.return_value = {"foo": "rabbitmq"}
+        mocked_deployment._load_message_queue(mocked_config)
+        m.assert_called_with(**{"foo": "rabbitmq"})
+
+    with mock.patch("llama_deploy.apiserver.deployment.RedisMessageQueue") as m:
+        mocked_config = mock.MagicMock(queue_type="redis")
+        mocked_config.model_dump.return_value = {"foo": "redis"}
+        mocked_deployment._load_message_queue(mocked_config)
+        m.assert_called_with(**{"foo": "redis"})
 
 
 def test_manager_ctor() -> None:

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -49,13 +49,6 @@ def test_deployment_ctor_skip_default_service(data_path: Path) -> None:
         assert len(d._workflow_services) == 1
 
 
-@pytest.mark.asyncio()
-async def test_deployment_start(mocked_deployment: Deployment) -> None:
-    mocked_deployment._start = mock.AsyncMock()  # type: ignore
-    mocked_deployment.start()
-    mocked_deployment._start.assert_called_once()
-
-
 def test_deployment___load_message_queue_default(mocked_deployment: Deployment) -> None:
     q = mocked_deployment._load_message_queue(None)
     assert type(q) is SimpleRemoteClientMessageQueue

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -6,7 +6,6 @@ import pytest
 
 from llama_deploy.apiserver.config_parser import Config
 from llama_deploy.apiserver.deployment import Deployment, Manager
-from llama_deploy.message_queues import SimpleMessageQueue
 from llama_deploy.control_plane import ControlPlaneServer
 
 
@@ -20,7 +19,7 @@ def test_deployment_ctor(data_path: Path) -> None:
         assert d.name == "TestDeployment"
         assert d.path.name == "TestDeployment"
         assert d.thread is None
-        assert type(d._queue) is SimpleMessageQueue
+        assert d._simple_message_queue_task is not None
         assert type(d._control_plane) is ControlPlaneServer
         assert len(d._workflow_services) == 1
 


### PR DESCRIPTION
Add a section in the deployment config file to define the message queue to use.

Notes:
- a string literal field `type` was added to the existing config models so that we can use it to tell Pydantic what's the right model to use when loading `message-queue` from the config

The format will be:
```yaml
message-queue:
  type: simple
  # this section depends on the type of the message queue and will be validated accordingly
  host: "127.0.0.1"
  port: 8001
```