### PR TITLE
ci: use ruff to format code instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.1.5
 
@@ -23,13 +24,8 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
         exclude: ".*poetry.lock"
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.10.1
-    hooks:
-      - id: black-jupyter
-        name: black-src
-        alias: black
-        exclude: ".*poetry.lock"
+      - id: ruff-format
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.1
     hooks:
@@ -50,6 +46,7 @@ repos:
             --python-version=3.11,
           ]
         exclude: ^(examples/|e2e_tests/)
+
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:
@@ -60,21 +57,19 @@ repos:
         additional_dependencies: [black==23.10.1]
         # Using PEP 8's line length in docs prevents excess left/right scrolling
         args: [--line-length=79]
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.3
     hooks:
       - id: prettier
         exclude: poetry.lock
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies: [tomli]
-  - repo: https://github.com/srstevenson/nb-clean
-    rev: 3.1.0
-    hooks:
-      - id: nb-clean
-        args: [--preserve-cell-outputs, --remove-empty-cells]
+
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.23.1
     hooks:

--- a/tests/message_queues/test_rabbitmq.py
+++ b/tests/message_queues/test_rabbitmq.py
@@ -70,9 +70,7 @@ async def test_publish(mock_connect: MagicMock) -> None:
     mq = RabbitMQMessageQueue()
     # mocks
     mock_exchange_publish = AsyncMock()
-    mock_connect.return_value.channel.return_value.declare_exchange.return_value.publish = (
-        mock_exchange_publish
-    )
+    mock_connect.return_value.channel.return_value.declare_exchange.return_value.publish = mock_exchange_publish
     # message types
     queue_message = QueueMessage(publisher_id="test", id_="1")
     message_body = json.dumps(queue_message.model_dump()).encode("utf-8")

--- a/tests/orchestrators/test_simple_orchestrator.py
+++ b/tests/orchestrators/test_simple_orchestrator.py
@@ -42,7 +42,10 @@ async def test_get_next_message() -> None:
     assert len(queue_messages) == 1
     assert queue_messages[0].type == INITIAL_QUEUE_MESSAGE.type
     assert isinstance(queue_messages[0].data, dict)
-    assert queue_messages[0].data["task"]["input"] == INITIAL_QUEUE_MESSAGE.data["task"]["input"]  # type: ignore
+    assert (
+        queue_messages[0].data["task"]["input"]
+        == INITIAL_QUEUE_MESSAGE.data["task"]["input"]
+    )  # type: ignore
 
     assert state[TASK_DEF.task_id] == {}
 


### PR DESCRIPTION
We already use Ruff for code linting, let's use it for formatting as well for faster iterations.