### PR TITLE
chore: rename --disable-ssl to --insecure

### DIFF
--- a/llama_deploy/cli/__init__.py
+++ b/llama_deploy/cli/__init__.py
@@ -12,14 +12,14 @@ from .status import status
 @click.option("-s", "--server", default="http://localhost:4501", help="Apiserver URL")
 @click.option(
     "-k",
-    "--disable-ssl",
+    "--insecure",
     default=False,
     is_flag=True,
     help="Disable SSL certificate verification",
 )
 @click.pass_context
-def llamactl(ctx: click.Context, server: str, disable_ssl: bool) -> None:
-    ctx.obj = server, disable_ssl
+def llamactl(ctx: click.Context, server: str, insecure: bool) -> None:
+    ctx.obj = server, insecure
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())  # show the help if no subcommand was provided
 


### PR DESCRIPTION
Minor change, was mentioned in the comments of another PR.

`llamactl` has an option to disable ssl validation when connecting to the apiserver: `-k` and `--disable-ssl`. Since `-k` was shamelessly stolen from `curl`, let's steal the long options as well, so that curl users won't be surprised.