### PR TITLE
feat: add `default-service` to the config spec

### DIFF
--- a/llama_deploy/apiserver/config_parser.py
+++ b/llama_deploy/apiserver/config_parser.py
@@ -58,6 +58,7 @@ class Config(BaseModel):
     name: str
     control_plane: ControlPlaneConfig = Field(alias="control-plane")
     message_queue: MessageQueueConfig | None = Field(None, alias="message-queue")
+    default_service: str | None = Field(None, alias="default-service")
     services: dict[str, Service]
 
     @classmethod

--- a/tests/apiserver/data/example.yaml
+++ b/tests/apiserver/data/example.yaml
@@ -8,6 +8,8 @@ message-queue:
   host: "127.0.0.1"
   port: 8001
 
+default-service: myworkflow
+
 services:
   myworkflow:
     # A python workflow available in a git repo

--- a/tests/apiserver/test_config_parser.py
+++ b/tests/apiserver/test_config_parser.py
@@ -10,6 +10,7 @@ def do_assert(config: Config) -> None:
 
     assert config.message_queue is not None
     assert config.message_queue.type == "simple"
+    assert config.default_service == "myworkflow"
 
     wf_config = config.services["myworkflow"]
     assert wf_config.name == "My Python Workflow"


### PR DESCRIPTION
When running a task for a deployment, users need to pass the service name where the task will be sent to. We expect most of the times this will be always the same service that acts as an "entrypoint" for the deployment, so we add a default configuration param in the deployment definition and let user omit it at task creation time.