### PR TITLE
ux: wrap httpx to uniform connection errors

### DIFF
--- a/llama_deploy/cli/deploy.py
+++ b/llama_deploy/cli/deploy.py
@@ -1,7 +1,8 @@
 from typing import IO
 
 import click
-import httpx
+
+from .utils import request
 
 
 @click.command()
@@ -12,7 +13,7 @@ def deploy(global_config: tuple, deployment_config_file: IO) -> None:
     deploy_url = f"{server_url}/deployments/create/"
 
     files = {"file": deployment_config_file.read()}
-    resp = httpx.post(deploy_url, files=files, verify=not disable_ssl)
+    resp = request("POST", deploy_url, files=files, verify=not disable_ssl)
 
     if resp.status_code >= 400:
         raise click.ClickException(resp.json().get("detail"))

--- a/llama_deploy/cli/status.py
+++ b/llama_deploy/cli/status.py
@@ -1,5 +1,7 @@
 import click
-import httpx
+
+
+from .utils import request
 
 
 @click.command()
@@ -8,13 +10,7 @@ def status(global_config: tuple) -> None:
     server_url, disable_ssl = global_config
     status_url = f"{server_url}/status/"
 
-    try:
-        r = httpx.get(status_url, verify=not disable_ssl)
-    except httpx.ConnectError:
-        raise click.ClickException(
-            f"Llama Deploy is not responding, check the apiserver address {server_url} is correct and try again."
-        )
-
+    r = request("GET", status_url, verify=not disable_ssl)
     if r.status_code >= 400:
         body = r.json()
         click.echo(

--- a/llama_deploy/cli/utils.py
+++ b/llama_deploy/cli/utils.py
@@ -13,6 +13,6 @@ def request(
     except httpx.ConnectError:
         parsed_url = urlparse(str(url))
         raise click.ClickException(
-            "Llama Deploy is not responding, check the apiserver "
+            "Llama Deploy is not responding, check that the apiserver "
             f"is running at {parsed_url.scheme}://{parsed_url.netloc} and try again."
         )

--- a/llama_deploy/cli/utils.py
+++ b/llama_deploy/cli/utils.py
@@ -1,0 +1,18 @@
+from typing import Any
+from urllib.parse import urlparse
+
+import click
+import httpx
+
+
+def request(
+    method: str, url: str | httpx.URL, *args: Any, **kwargs: Any
+) -> httpx.Response:
+    try:
+        return httpx.request(method, url, *args, **kwargs)
+    except httpx.ConnectError:
+        parsed_url = urlparse(str(url))
+        raise click.ClickException(
+            "Llama Deploy is not responding, check the apiserver "
+            f"is running at {parsed_url.scheme}://{parsed_url.netloc} and try again."
+        )

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -9,13 +9,14 @@ from llama_deploy.cli import llamactl
 def test_deploy(runner: CliRunner, data_path: Path) -> None:
     test_config_file = data_path / "deployment.yaml"
     mocked_response = mock.MagicMock(status_code=200, json=lambda: {})
-    with mock.patch("llama_deploy.cli.deploy.httpx") as mocked_httpx:
-        mocked_httpx.post.return_value = mocked_response
+    with mock.patch("llama_deploy.cli.deploy.request") as mocked_httpx:
+        mocked_httpx.return_value = mocked_response
         result = runner.invoke(llamactl, ["deploy", str(test_config_file)])
 
         assert result.exit_code == 0
         with open(test_config_file, "rb") as f:
-            mocked_httpx.post.assert_called_with(
+            mocked_httpx.assert_called_with(
+                "POST",
                 "http://localhost:4501/deployments/create/",
                 files={"file": f.read()},
                 verify=True,
@@ -27,8 +28,8 @@ def test_deploy_failed(runner: CliRunner, data_path: Path) -> None:
     mocked_response = mock.MagicMock(
         status_code=401, json=lambda: {"detail": "Unauthorized!"}
     )
-    with mock.patch("llama_deploy.cli.deploy.httpx") as mocked_httpx:
-        mocked_httpx.post.return_value = mocked_response
+    with mock.patch("llama_deploy.cli.deploy.request") as mocked_httpx:
+        mocked_httpx.return_value = mocked_response
         result = runner.invoke(llamactl, ["deploy", str(test_config_file)])
         assert result.exit_code == 1
         assert result.output == "Error: Unauthorized!\n"

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -13,8 +13,8 @@ def test_status_server_down(runner: CliRunner) -> None:
 
 def test_status_unhealthy(runner: CliRunner) -> None:
     mocked_response = mock.MagicMock(status_code=500)
-    with mock.patch("llama_deploy.cli.status.httpx") as mocked_httpx:
-        mocked_httpx.get.return_value = mocked_response
+    with mock.patch("llama_deploy.cli.status.request") as mocked_httpx:
+        mocked_httpx.return_value = mocked_response
         result = runner.invoke(llamactl, ["status"])
         assert result.exit_code == 0
         assert "Llama Deploy is unhealthy: [500]" in result.output
@@ -22,8 +22,8 @@ def test_status_unhealthy(runner: CliRunner) -> None:
 
 def test_status(runner: CliRunner) -> None:
     mocked_response = mock.MagicMock(status_code=200, json=lambda: {})
-    with mock.patch("llama_deploy.cli.status.httpx") as mocked_httpx:
-        mocked_httpx.get.return_value = mocked_response
+    with mock.patch("llama_deploy.cli.status.request") as mocked_httpx:
+        mocked_httpx.return_value = mocked_response
         result = runner.invoke(llamactl, ["status"])
         assert result.exit_code == 0
         assert (
@@ -35,8 +35,8 @@ def test_status(runner: CliRunner) -> None:
 def test_status_with_deployments(runner: CliRunner) -> None:
     mocked_response = mock.MagicMock(status_code=200)
     mocked_response.json.return_value = {"deployments": ["foo", "bar"]}
-    with mock.patch("llama_deploy.cli.status.httpx") as mocked_httpx:
-        mocked_httpx.get.return_value = mocked_response
+    with mock.patch("llama_deploy.cli.status.request") as mocked_httpx:
+        mocked_httpx.return_value = mocked_response
         result = runner.invoke(llamactl, ["status"])
         assert result.exit_code == 0
         assert result.output == (


### PR DESCRIPTION
Pretty much any command in the CLI will try to connect to the apiserver. To avoid repeating over and over the try/catch block for `httpx.ConnectionError` and possibly make the error message not consistent across the codebase, we wrap `httpx` into an utility method.