### PR TITLE
feat: add `--timeout` to the CLI

### DIFF
--- a/llama_deploy/cli/__init__.py
+++ b/llama_deploy/cli/__init__.py
@@ -18,9 +18,10 @@ from .status import status
     is_flag=True,
     help="Disable SSL certificate verification",
 )
+@click.option("-t", "--timeout", default=5.0, help="Timeout on apiserver HTTP requests")
 @click.pass_context
-def llamactl(ctx: click.Context, server: str, insecure: bool) -> None:
-    ctx.obj = server, insecure
+def llamactl(ctx: click.Context, server: str, insecure: bool, timeout: float) -> None:
+    ctx.obj = server, insecure, timeout
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())  # show the help if no subcommand was provided
 

--- a/llama_deploy/cli/__init__.py
+++ b/llama_deploy/cli/__init__.py
@@ -18,9 +18,17 @@ from .status import status
     is_flag=True,
     help="Disable SSL certificate verification",
 )
-@click.option("-t", "--timeout", default=5.0, help="Timeout on apiserver HTTP requests")
+@click.option(
+    "-t",
+    "--timeout",
+    default=None,
+    type=float,
+    help="Timeout on apiserver HTTP requests",
+)
 @click.pass_context
-def llamactl(ctx: click.Context, server: str, insecure: bool, timeout: float) -> None:
+def llamactl(
+    ctx: click.Context, server: str, insecure: bool, timeout: float | None
+) -> None:
     ctx.obj = server, insecure, timeout
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())  # show the help if no subcommand was provided

--- a/llama_deploy/cli/deploy.py
+++ b/llama_deploy/cli/deploy.py
@@ -9,11 +9,13 @@ from .utils import request
 @click.pass_obj  # global_config
 @click.argument("deployment_config_file", type=click.File("rb"))
 def deploy(global_config: tuple, deployment_config_file: IO) -> None:
-    server_url, disable_ssl = global_config
+    server_url, disable_ssl, timeout = global_config
     deploy_url = f"{server_url}/deployments/create"
 
     files = {"config_file": deployment_config_file.read()}
-    resp = request("POST", deploy_url, files=files, verify=not disable_ssl)
+    resp = request(
+        "POST", deploy_url, files=files, verify=not disable_ssl, timeout=timeout
+    )
 
     if resp.status_code >= 400:
         raise click.ClickException(resp.json().get("detail"))

--- a/llama_deploy/cli/run.py
+++ b/llama_deploy/cli/run.py
@@ -26,13 +26,13 @@ def run(
     arg: tuple[tuple[str, str]],
     service: str,
 ) -> None:
-    server_url, insecure = global_config
+    server_url, disable_ssl, timeout = global_config
     deploy_url = f"{server_url}/deployments/{deployment}/tasks/create"
     payload = {"input": json.dumps(dict(arg))}
     if service:
         payload["agent_id"] = service
 
-    resp = httpx.post(deploy_url, verify=not insecure, json=payload)
+    resp = httpx.post(deploy_url, verify=not disable_ssl, json=payload, timeout=timeout)
 
     if resp.status_code >= 400:
         raise click.ClickException(resp.json().get("detail"))

--- a/llama_deploy/cli/status.py
+++ b/llama_deploy/cli/status.py
@@ -7,10 +7,10 @@ from .utils import request
 @click.command()
 @click.pass_obj  # global_config
 def status(global_config: tuple) -> None:
-    server_url, disable_ssl = global_config
+    server_url, disable_ssl, timeout = global_config
     status_url = f"{server_url}/status/"
 
-    r = request("GET", status_url, verify=not disable_ssl)
+    r = request("GET", status_url, verify=not disable_ssl, timeout=timeout)
     if r.status_code >= 400:
         body = r.json()
         click.echo(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -11,7 +11,7 @@ def test_deploy(runner: CliRunner, data_path: Path) -> None:
     mocked_response = mock.MagicMock(status_code=200, json=lambda: {})
     with mock.patch("llama_deploy.cli.deploy.request") as mocked_httpx:
         mocked_httpx.return_value = mocked_response
-        result = runner.invoke(llamactl, ["deploy", str(test_config_file)])
+        result = runner.invoke(llamactl, ["-t", 5.0, "deploy", str(test_config_file)])
 
         assert result.exit_code == 0
         with open(test_config_file, "rb") as f:
@@ -20,7 +20,7 @@ def test_deploy(runner: CliRunner, data_path: Path) -> None:
                 "http://localhost:4501/deployments/create",
                 files={"config_file": f.read()},
                 verify=True,
-                timeout=5.0,
+                timeout=5,
             )
 
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -20,6 +20,7 @@ def test_deploy(runner: CliRunner, data_path: Path) -> None:
                 "http://localhost:4501/deployments/create",
                 files={"config_file": f.read()},
                 verify=True,
+                timeout=5.0,
             )
 
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -16,6 +16,7 @@ def test_run(runner: CliRunner) -> None:
             "http://localhost:4501/deployments/deployment_name/tasks/create",
             verify=True,
             json={"input": "{}", "agent_id": "service_name"},
+            timeout=5.0,
         )
         assert result.exit_code == 0
 
@@ -55,5 +56,6 @@ def test_run_args(runner: CliRunner) -> None:
             json={
                 "input": '{"first_arg": "first_value", "second_arg": "\\"second value with spaces\\""}',
             },
+            timeout=5.0,
         )
         assert result.exit_code == 0

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -16,7 +16,7 @@ def test_run(runner: CliRunner) -> None:
             "http://localhost:4501/deployments/deployment_name/tasks/create",
             verify=True,
             json={"input": "{}", "agent_id": "service_name"},
-            timeout=5.0,
+            timeout=None,
         )
         assert result.exit_code == 0
 
@@ -56,6 +56,6 @@ def test_run_args(runner: CliRunner) -> None:
             json={
                 "input": '{"first_arg": "first_value", "second_arg": "\\"second value with spaces\\""}',
             },
-            timeout=5.0,
+            timeout=None,
         )
         assert result.exit_code == 0

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -6,8 +6,9 @@ from llama_deploy.cli import llamactl
 
 
 def test_status_server_down(runner: CliRunner) -> None:
-    result = runner.invoke(llamactl, ["status"])
+    result = runner.invoke(llamactl, ["-s", "https://test", "status"])
     assert result.exit_code == 1
+    print(result.output)
     assert "Error: Llama Deploy is not responding" in result.output
 
 


### PR DESCRIPTION
Default timeout for `httpx` is 5 seconds, but `llamactl deploy` for complex deployments can last more and let the CLI fail with a timeout error. 

As an alternative, we might have a longer, dedicated timeout for the `deploy` command but whatever value we pick, it will look as a magic number, so I preferred to add a global option and leave the burden to the user