### PR TITLE
feat: install service dependencies in the apiserver

### DIFF
--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -127,13 +127,7 @@ class Deployment:
     def _load_services(self, config: Config) -> list[WorkflowService]:
         """Creates WorkflowService instances according to the configuration object."""
         workflow_services = []
-        default_port = 8002
         for service_id, service_config in config.services.items():
-            port = service_config.port
-            if not port:
-                port = default_port
-                default_port += 1
-
             source = service_config.source
             if source is None:
                 # this is a default service, skip for now
@@ -162,9 +156,9 @@ class Deployment:
             workflow = getattr(module, workflow_name)
             workflow_config = WorkflowServiceConfig(
                 host="workflow",
-                port=port,
+                port=8002,
                 internal_host="0.0.0.0",
-                internal_port=port,
+                internal_port=8002,
                 service_name=workflow_name,
             )
             workflow_services.append(

--- a/tests/apiserver/data/python_dependencies.yaml
+++ b/tests/apiserver/data/python_dependencies.yaml
@@ -1,0 +1,18 @@
+name: MyDeployment
+
+control-plane:
+  port: 8000
+
+message-queue:
+  type: simple
+  host: "127.0.0.1"
+  port: 8001
+
+default-service: myworkflow
+
+services:
+  myworkflow:
+    name: My Python Workflow
+    python-dependencies:
+      - "llama-index-core<1"
+      - "llama-index-llms-openai"


### PR DESCRIPTION
When deploying a Service, run `pip install` on the list under `python-dependencies` in the configuration file.

Note that the current implementation of the apiserver is single process, so the dependencies will be installed in the virtual environment of the apiserver itself. This solution is good enough for the POC but will be improved as we get closer to production readiness.