### PR TITLE
feat: add services port management

### DIFF
--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -121,7 +121,13 @@ class Deployment:
     def _load_services(self, config: Config) -> list[WorkflowService]:
         """Creates WorkflowService instances according to the configuration object."""
         workflow_services = []
+        default_port = 8002
         for service_id, service_config in config.services.items():
+            port = service_config.port
+            if not port:
+                port = default_port
+                default_port += 1
+
             source = service_config.source
             if source is None:
                 # this is a default service, skip for now
@@ -147,9 +153,9 @@ class Deployment:
             workflow = getattr(module, workflow_name)
             workflow_config = WorkflowServiceConfig(
                 host="workflow",
-                port=8002,
+                port=port,
                 internal_host="0.0.0.0",
-                internal_port=8002,
+                internal_port=port,
                 service_name=workflow_name,
             )
             workflow_services.append(

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -134,6 +134,11 @@ class Deployment:
                 msg = "path field in service definition must be set"
                 raise ValueError(msg)
 
+            if service_config.port is None:
+                # This won't happen if we arrive here from Manager.deploy(), the manager will assign a port
+                msg = "port field in service definition must be set"
+                raise ValueError(msg)
+
             # Sync the service source
             destination = self._path / service_id
             source_manager = SOURCE_MANAGERS[source.type]
@@ -147,7 +152,7 @@ class Deployment:
             workflow = getattr(module, workflow_name)
             workflow_config = WorkflowServiceConfig(
                 host="workflow",
-                port=service_config.port,  # type: ignore # (service_config.port is set by the Manager and can't be None)
+                port=service_config.port,
                 internal_host="0.0.0.0",
                 internal_port=service_config.port,
                 service_name=workflow_name,

--- a/tests/apiserver/data/git_service.yaml
+++ b/tests/apiserver/data/git_service.yaml
@@ -5,6 +5,7 @@ control-plane: {}
 services:
   test-workflow:
     name: Test Workflow
+    port: 8002
     source:
       type: git
       name: https://github.com/run-llama/llama_deploy.git

--- a/tests/apiserver/data/service_ports.yaml
+++ b/tests/apiserver/data/service_ports.yaml
@@ -1,0 +1,14 @@
+name: TestDeployment
+
+control-plane: {}
+
+services:
+  no-port:
+    name: No Port
+
+  has-port:
+    name: Has Port
+    port: 9999
+
+  no-port-again:
+    name: Again no Port

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -153,3 +153,12 @@ async def test_manager_serve_loop() -> None:
     await serve_task
     assert serve_task.done()
     assert serve_task.exception() is None
+
+
+def test_manager_assign_control_plane_port(data_path: Path) -> None:
+    m = Manager()
+    config = Config.from_yaml(data_path / "service_ports.yaml")
+    m._assign_control_plane_port(config)
+    assert config.services["no-port"].port == 8002
+    assert config.services["has-port"].port == 9999
+    assert config.services["no-port-again"].port == 8003


### PR DESCRIPTION
Service port was hardcoded, meaning two services couldn't be started in the same deployment. With this PR:
- if the port was specified in the config file, the user is responsible to avoid clashes
- if the port is empty in the config file, the manager will keep track of the last port used and increment the next one