### PR TITLE
endpoints for create task nowait and getting event stream

### DIFF
--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -37,11 +37,11 @@ async def read_deployment(deployment_name: str) -> JSONResponse:
     )
 
 
-@deployments_router.post("/{deployment_name}/tasks/create")
+@deployments_router.post("/{deployment_name}/tasks/run")
 async def create_deployment_task(
     deployment_name: str, task_definition: TaskDefinition
 ) -> JSONResponse:
-    """Create a task for the deployment."""
+    """Create a task for the deployment, wait for result and delete associated session."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
@@ -63,11 +63,11 @@ async def create_deployment_task(
     return JSONResponse(result)
 
 
-@deployments_router.post("/{deployment_name}/tasks/create_nowait")
+@deployments_router.post("/{deployment_name}/tasks/create")
 async def create_deployment_task_nowait(
     deployment_name: str, task_definition: TaskDefinition
 ) -> JSONResponse:
-    """Create a task for the deployment and don't wait for result."""
+    """Create a task for the deployment but don't wait for result."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -137,3 +137,27 @@ async def create_deployment(config_file: UploadFile = File(...)) -> JSONResponse
             "name": config.name,
         }
     )
+
+
+@deployments_router.get("/{deployment_name}/sessions")
+async def get_sessions(
+    deployment_name: str,
+) -> JSONResponse:
+    """Get the active sessions in a deployment and service."""
+    deployment = manager.get_deployment(deployment_name)
+    if deployment is None:
+        raise HTTPException(status_code=404, detail="Deployment not found")
+
+    sessions = await deployment.client.list_sessions()
+    return JSONResponse(sessions)
+
+
+@deployments_router.get("/{deployment_name}/sessions/delete")
+async def delete_session(deployment_name: str, session_id: str) -> JSONResponse:
+    """Get the active sessions in a deployment and service."""
+    deployment = manager.get_deployment(deployment_name)
+    if deployment is None:
+        raise HTTPException(status_code=404, detail="Deployment not found")
+
+    await deployment.client.delete_session(session_id)
+    return JSONResponse({"session_id": session_id, "status": "Deleted"})

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -88,7 +88,7 @@ async def create_deployment_task_nowait(
     return JSONResponse({"session_id": session.session_id, "task_id": task_id})
 
 
-@deployments_router.get("/{deployment_name}/events/")
+@deployments_router.get("/{deployment_name}/events")
 async def get_events(
     deployment_name: str, session_id: str, task_id: str
 ) -> StreamingResponse:

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -1,11 +1,13 @@
 import json
 
 from fastapi import APIRouter, File, UploadFile, HTTPException
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
+from typing import AsyncGenerator
 
 from llama_deploy.apiserver.server import manager
 from llama_deploy.apiserver.config_parser import Config
 from llama_deploy.types import TaskDefinition
+
 
 deployments_router = APIRouter(
     prefix="/deployments",
@@ -57,6 +59,68 @@ async def create_deployment_task(
         task_definition.agent_id or "", **json.loads(task_definition.input)
     )
     await deployment.client.delete_session(session.session_id)
+
+    return JSONResponse(result)
+
+
+@deployments_router.post("/{deployment_name}/tasks/create_nowait")
+async def create_deployment_task_nowait(
+    deployment_name: str, task_definition: TaskDefinition
+) -> JSONResponse:
+    """Create a task for the deployment and don't wait for result."""
+    deployment = manager.get_deployment(deployment_name)
+    if deployment is None:
+        raise HTTPException(status_code=404, detail="Deployment not found")
+
+    if task_definition.agent_id is None:
+        if deployment.default_service is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Service is None and deployment has no default service",
+            )
+        task_definition.agent_id = deployment.default_service
+
+    session = await deployment.client.create_session()
+    task_id = await session.run_nowait(
+        task_definition.agent_id or "", **json.loads(task_definition.input)
+    )
+
+    return JSONResponse({"session_id": session.session_id, "task_id": task_id})
+
+
+@deployments_router.get("/{deployment_name}/events/")
+async def get_events(
+    deployment_name: str, session_id: str, task_id: str
+) -> StreamingResponse:
+    """Get the stream of events from a given task and session."""
+    deployment = manager.get_deployment(deployment_name)
+    if deployment is None:
+        raise HTTPException(status_code=404, detail="Deployment not found")
+
+    session = await deployment.client.get_session(session_id)
+
+    async def event_stream() -> AsyncGenerator[str, None]:
+        # need to convert back to str to use SSE
+        async for event in session.get_task_result_stream(task_id):
+            yield json.dumps(event) + "\n"
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="application/x-ndjson",
+    )
+
+
+@deployments_router.get("/{deployment_name}/tasks/results")
+async def get_task_result(
+    deployment_name: str, session_id: str, task_id: str
+) -> JSONResponse:
+    """Get the task result associated with a task and session."""
+    deployment = manager.get_deployment(deployment_name)
+    if deployment is None:
+        raise HTTPException(status_code=404, detail="Deployment not found")
+
+    session = await deployment.client.get_session(session_id)
+    result = session.get_task_result(task_id)
 
     return JSONResponse(result)
 

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -110,7 +110,7 @@ async def get_events(
     )
 
 
-@deployments_router.get("/{deployment_name}/tasks/results")
+@deployments_router.get("/{deployment_name}/results")
 async def get_task_result(
     deployment_name: str, session_id: str, task_id: str
 ) -> JSONResponse:
@@ -120,9 +120,9 @@ async def get_task_result(
         raise HTTPException(status_code=404, detail="Deployment not found")
 
     session = await deployment.client.get_session(session_id)
-    result = session.get_task_result(task_id)
+    result = await session.get_task_result(task_id)
 
-    return JSONResponse(result)
+    return JSONResponse(result.result if result else "")
 
 
 @deployments_router.post("/create")

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -152,7 +152,7 @@ async def get_sessions(
     return JSONResponse(sessions)
 
 
-@deployments_router.get("/{deployment_name}/sessions/delete")
+@deployments_router.post("/{deployment_name}/sessions/delete")
 async def delete_session(deployment_name: str, session_id: str) -> JSONResponse:
     """Get the active sessions in a deployment and service."""
     deployment = manager.get_deployment(deployment_name)

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -177,3 +177,19 @@ def test_get_task_result(http_client: TestClient, data_path: Path) -> None:
         assert response.json() == "test_result"
         session.get_task_result.assert_called_with("test_task_id")
         deployment.client.get_session.assert_called_with("42")
+
+
+def test_get_sessions(http_client: TestClient, data_path: Path) -> None:
+    with mock.patch(
+        "llama_deploy.apiserver.routers.deployments.manager"
+    ) as mocked_manager:
+        deployment = mock.AsyncMock()
+        deployment.default_service = "TestService"
+        deployment.client.list_sessions.return_value = []
+        mocked_manager.get_deployment.return_value = deployment
+
+        response = http_client.get(
+            "/deployments/test-deployment/sessions/",
+        )
+        assert response.status_code == 200
+        assert response.json() == []

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -193,3 +193,19 @@ def test_get_sessions(http_client: TestClient, data_path: Path) -> None:
         )
         assert response.status_code == 200
         assert response.json() == []
+
+
+def test_delete_session(http_client: TestClient, data_path: Path) -> None:
+    with mock.patch(
+        "llama_deploy.apiserver.routers.deployments.manager"
+    ) as mocked_manager:
+        deployment = mock.AsyncMock()
+        deployment.default_service = "TestService"
+        mocked_manager.get_deployment.return_value = deployment
+
+        response = http_client.post(
+            "/deployments/test-deployment/sessions/delete/?session_id=42",
+        )
+        assert response.status_code == 200
+        assert response.json() == {"session_id": "42", "status": "Deleted"}
+        deployment.client.delete_session.assert_called_with("42")

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -144,7 +144,7 @@ async def test_get_event_stream(http_client: TestClient, data_path: Path) -> Non
         session.get_task_result_stream.return_value = mocked_get_task_result_stream
 
         response = http_client.get(
-            "/deployments/test-deployment/events/?session_id=42&task_id=test_task_id",
+            "/deployments/test-deployment/tasks/test_task_id/events/?session_id=42",
         )
         assert response.status_code == 200
         ix = 0
@@ -153,6 +153,7 @@ async def test_get_event_stream(http_client: TestClient, data_path: Path) -> Non
             assert data == mock_events[ix].dict()
             ix += 1
         deployment.client.get_session.assert_called_with("42")
+        session.get_task_result_stream.assert_called_with("test_task_id")
 
 
 def test_get_task_result(http_client: TestClient, data_path: Path) -> None:
@@ -169,7 +170,7 @@ def test_get_task_result(http_client: TestClient, data_path: Path) -> None:
         mocked_manager.get_deployment.return_value = deployment
 
         response = http_client.get(
-            "/deployments/test-deployment/results/?session_id=42&task_id=test_task_id",
+            "/deployments/test-deployment/tasks/test_task_id/results/?session_id=42",
         )
         assert response.status_code == 200
         assert response.json() == "test_result"

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -92,7 +92,7 @@ def test_create_deployment_task(http_client: TestClient, data_path: Path) -> Non
         session = mock.AsyncMock()
         deployment.client.create_session.return_value = session
         session.run.return_value = {"result": "test_result"}
-        session.session_id = str(42)
+        session.session_id = "42"
         mocked_manager.get_deployment.return_value = deployment
         response = http_client.post(
             "/deployments/test-deployment/tasks/create/",

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -83,7 +83,7 @@ def test_create_deployment_task_missing_service(
         )
 
 
-def test_create_deployment_task(http_client: TestClient, data_path: Path) -> None:
+def test_run_deployment_task(http_client: TestClient, data_path: Path) -> None:
     with mock.patch(
         "llama_deploy.apiserver.routers.deployments.manager"
     ) as mocked_manager:
@@ -95,16 +95,14 @@ def test_create_deployment_task(http_client: TestClient, data_path: Path) -> Non
         session.session_id = "42"
         mocked_manager.get_deployment.return_value = deployment
         response = http_client.post(
-            "/deployments/test-deployment/tasks/create/",
+            "/deployments/test-deployment/tasks/run/",
             json={"input": "{}"},
         )
         assert response.status_code == 200
         deployment.client.delete_session.assert_called_with("42")
 
 
-def test_create_deployment_task_nowait(
-    http_client: TestClient, data_path: Path
-) -> None:
+def test_create_deployment_task(http_client: TestClient, data_path: Path) -> None:
     with mock.patch(
         "llama_deploy.apiserver.routers.deployments.manager"
     ) as mocked_manager:
@@ -116,7 +114,7 @@ def test_create_deployment_task_nowait(
         session.run_nowait.return_value = "test_task_id"
         mocked_manager.get_deployment.return_value = deployment
         response = http_client.post(
-            "/deployments/test-deployment/tasks/create_nowait/",
+            "/deployments/test-deployment/tasks/create/",
             json={"input": "{}"},
         )
         assert response.status_code == 200


### PR DESCRIPTION
Adds the following endpoints to `deployments` router of API Server:

- `post("/{deployment_name}/tasks/create_nowait")` -> returns session id and task id
- `get("/{deployment_name}/events")` -> returns SSE of event.model_dump()
- `get("/{deployment_name}/results")` -> returns result string of task
- `get("/{deployment_name}/sessions")` -> returns list of active sessions
- `post("/{deployment_name}/sessions/delete")` -> deletes an active session

Where applicable, I've used `query params` instead of path params. If we prefer the latter, I can make a quick fix.