### PR TITLE
lazy init the message queue configs

### DIFF
--- a/docker/docker-compose-awssqs.yml
+++ b/docker/docker-compose-awssqs.yml
@@ -1,6 +1,6 @@
 services:
   control_plane:
-    image: llamaindex/llama-deploy:v0.1.3
+    image: llamaindex/llama-deploy:v0.2.1
     environment:
       CONTROL_PLANE_HOST: control_plane
       CONTROL_PLANE_PORT: 8000

--- a/docker/docker-compose-kafka.yml
+++ b/docker/docker-compose-kafka.yml
@@ -29,7 +29,7 @@ services:
       retries: 5
 
   control_plane:
-    image: llamaindex/llama-deploy:v0.1.3
+    image: llamaindex/llama-deploy:v0.2.1
     environment:
       CONTROL_PLANE_HOST: control_plane
       CONTROL_PLANE_PORT: 8000

--- a/docker/docker-compose-rabbitmq.yml
+++ b/docker/docker-compose-rabbitmq.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   control_plane:
-    image: llamaindex/llama-deploy:v0.1.3
+    image: llamaindex/llama-deploy:v0.2.1
     environment:
       CONTROL_PLANE_HOST: control_plane
       CONTROL_PLANE_PORT: 8000

--- a/docker/docker-compose-redis.yml
+++ b/docker/docker-compose-redis.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   control_plane:
-    image: llamaindex/llama-deploy:v0.1.3
+    image: llamaindex/llama-deploy:v0.2.1
     environment:
       CONTROL_PLANE_HOST: control_plane
       CONTROL_PLANE_PORT: 8000

--- a/docker/docker-compose-simple.yml
+++ b/docker/docker-compose-simple.yml
@@ -1,6 +1,6 @@
 services:
   message_queue:
-    image: llamaindex/llama-deploy:v0.1.3
+    image: llamaindex/llama-deploy:v0.2.1
     environment:
       SIMPLE_MESSAGE_QUEUE_HOST: message_queue
       SIMPLE_MESSAGE_QUEUE_PORT: 8001
@@ -16,7 +16,7 @@ services:
       start_period: 20s
 
   control_plane:
-    image: llamaindex/llama-deploy:v0.1.3
+    image: llamaindex/llama-deploy:v0.2.1
     environment:
       CONTROL_PLANE_HOST: control_plane
       CONTROL_PLANE_PORT: 8000

--- a/examples/message-queue-integrations/_app/multi_workflows_app/deployment/core.py
+++ b/examples/message-queue-integrations/_app/multi_workflows_app/deployment/core.py
@@ -13,11 +13,11 @@ from llama_deploy.message_queues.aws import AWSMessageQueueConfig
 control_plane_config = ControlPlaneConfig()
 
 message_queue_configs = {
-    "kafka": KafkaMessageQueueConfig(),
-    "rabbitmq": RabbitMQMessageQueueConfig(),
-    "redis": RedisMessageQueueConfig(),
-    "aws": AWSMessageQueueConfig(),
-    "simple": SimpleMessageQueueConfig(),
+    "kafka": KafkaMessageQueueConfig,
+    "rabbitmq": RabbitMQMessageQueueConfig,
+    "redis": RedisMessageQueueConfig,
+    "aws": AWSMessageQueueConfig,
+    "simple": SimpleMessageQueueConfig,
 }
 
 
@@ -45,7 +45,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    message_queue_config = message_queue_configs[args.message_queue]
+    # initialize the message queue config
+    message_queue_config = message_queue_configs[args.message_queue]()
+
     asyncio.run(
         deploy_core(
             control_plane_config=control_plane_config,

--- a/examples/message-queue-integrations/_app/pyproject.toml
+++ b/examples/message-queue-integrations/_app/pyproject.toml
@@ -14,4 +14,4 @@ python = "^3.10"
 llama-index-llms-openai = "^0.2.1"
 llama-index-embeddings-openai = "^0.2.4"
 llama-index-agent-openai = "^0.3.0"
-llama-deploy = {version = "^0.1.3a0", extras = ["awssqs", "rabbitmq", "kafka", "redis"]}
+llama-deploy = {version = "^0.2.1", extras = ["awssqs", "rabbitmq", "kafka", "redis"]}


### PR DESCRIPTION
In this example, we should lazy-init the message queue configs to avoid requiring certain env variables 