### PR TITLE
chore: do not report coverage for test code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ skip = "poetry.lock,./examples,*/algolia.js,docs/poetry.lock"
 
 [tool.coverage.run]
 omit = [
-  "__main__.py"
+  "__main__.py",
+  "tests/*"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
We're currently including files under `tests/` for calculating the coverage, let's ignore them instead.

Note: coveralls check is expected to fail, because we're removing false positives and actual coverage is supposed to go down.