### PR TITLE
fix cli run command

### DIFF
--- a/llama_deploy/cli/run.py
+++ b/llama_deploy/cli/run.py
@@ -27,7 +27,7 @@ def run(
     service: str,
 ) -> None:
     server_url, disable_ssl, timeout = global_config
-    deploy_url = f"{server_url}/deployments/{deployment}/tasks/create"
+    deploy_url = f"{server_url}/deployments/{deployment}/tasks/run"
     payload = {"input": json.dumps(dict(arg))}
     if service:
         payload["agent_id"] = service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ omit = [
 
 [tool.poetry]
 name = "llama-deploy"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = ["Logan Markewich <logan.markewich@live.com>", "Andrei Fajardo <andrei@runllama.ai>"]
 maintainers = [

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -13,7 +13,7 @@ def test_run(runner: CliRunner) -> None:
             llamactl, ["run", "-d", "deployment_name", "-s", "service_name"]
         )
         mocked_httpx.post.assert_called_with(
-            "http://localhost:4501/deployments/deployment_name/tasks/create",
+            "http://localhost:4501/deployments/deployment_name/tasks/run",
             verify=True,
             json={"input": "{}", "agent_id": "service_name"},
             timeout=None,
@@ -51,7 +51,7 @@ def test_run_args(runner: CliRunner) -> None:
             ],
         )
         mocked_httpx.post.assert_called_with(
-            "http://localhost:4501/deployments/deployment_name/tasks/create",
+            "http://localhost:4501/deployments/deployment_name/tasks/run",
             verify=True,
             json={
                 "input": '{"first_arg": "first_value", "second_arg": "\\"second value with spaces\\""}',


### PR DESCRIPTION
The /task/create endpoint no longer blocks and returns a result, switch the endpoint being called to /task/run