### PR TITLE
fix: remove timeout from the underlying network service

### DIFF
--- a/llama_deploy/deploy/network_workflow.py
+++ b/llama_deploy/deploy/network_workflow.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from llama_index.core.workflow import Workflow, StopEvent, StartEvent, step
+from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
 from llama_index.core.workflow.service import ServiceManager, ServiceNotFoundError
 
 from llama_deploy.client.async_client import AsyncLlamaDeployClient
@@ -60,7 +60,7 @@ class NetworkServiceManager(ServiceManager):
 
         # If the remove service exists, swap it in
         if remote_service is not None:
-            return NetworkWorkflow(self.control_plane_config, name)
+            return NetworkWorkflow(self.control_plane_config, name, timeout=None)
 
         # else default to the local workflow -- if it exists
         if local_workflow is None:


### PR DESCRIPTION
Fixes #320 

When deploying nested workflows, another "system" workflow `NetworkWorkflow` is started under the hood to provide a map workflow<-->service. This workflow has no timeout set, defaulting to 10s. But if the overall deployment requires more than 10 seconds to run, `NetworkWorkflow` will exit before the deployment can finish, causing #320 

We should probably review the strategy of `NetworkWorkflow`, specially when nested workflows are involved, but for the time being this fix should be good.

I didn't find a way to meaningfully unit test this, and a proper e2e test would take >10s so I propose we don't test it.