### PR TITLE
Add ability to `send_event` to a Worfklow's service ongoing task/run.

### DIFF
--- a/e2e_tests/basic_hitl/conftest.py
+++ b/e2e_tests/basic_hitl/conftest.py
@@ -1,0 +1,55 @@
+import asyncio
+import multiprocessing
+import time
+
+import pytest
+
+from llama_deploy import (
+    ControlPlaneConfig,
+    SimpleMessageQueueConfig,
+    WorkflowServiceConfig,
+    deploy_core,
+    deploy_workflow,
+)
+
+from .workflow import HumanInTheLoopWorkflow
+
+
+def run_async_core():
+    asyncio.run(deploy_core(ControlPlaneConfig(), SimpleMessageQueueConfig()))
+
+
+@pytest.fixture(scope="package")
+def core():
+    p = multiprocessing.Process(target=run_async_core)
+    p.start()
+    time.sleep(5)
+
+    yield
+
+    p.kill()
+
+
+def run_async_workflow():
+    asyncio.run(
+        deploy_workflow(
+            HumanInTheLoopWorkflow(timeout=60),
+            WorkflowServiceConfig(
+                host="127.0.0.1",
+                port=8002,
+                service_name="hitl_workflow",
+            ),
+            ControlPlaneConfig(),
+        )
+    )
+
+
+@pytest.fixture(scope="package")
+def services(core):
+    p = multiprocessing.Process(target=run_async_workflow)
+    p.start()
+    time.sleep(5)
+
+    yield
+
+    p.kill()

--- a/e2e_tests/basic_hitl/test_run_client.py
+++ b/e2e_tests/basic_hitl/test_run_client.py
@@ -1,0 +1,75 @@
+import asyncio
+import pytest
+import time
+
+from llama_deploy import AsyncLlamaDeployClient, ControlPlaneConfig, LlamaDeployClient
+from llama_index.core.workflow.events import HumanResponseEvent
+
+
+@pytest.mark.e2ehitl
+def test_run_client(services):
+    client = LlamaDeployClient(ControlPlaneConfig(), timeout=10)
+
+    # sanity check
+    sessions = client.list_sessions()
+    assert len(sessions) == 0, "Sessions list is not empty"
+
+    # create a session
+    session = client.create_session()
+
+    # kick off run
+    task_id = session.run_nowait("hitl_workflow")
+
+    # send event
+    session.send_event(
+        ev=HumanResponseEvent(response="42"),
+        service_name="hitl_workflow",
+        task_id=task_id,
+    )
+
+    # get final result, polling to wait for workflow to finish after send event
+    final_result = None
+    while final_result is None:
+        final_result = session.get_task_result(task_id)
+        time.sleep(0.1)
+    assert final_result.result == "42", "The human's response is not consistent."
+
+    # delete the session
+    client.delete_session(session.session_id)
+    sessions = client.list_sessions()
+    assert len(sessions) == 0, "Sessions list is not empty"
+
+
+@pytest.mark.e2ehitl
+@pytest.mark.asyncio
+async def test_run_client_async(services):
+    client = AsyncLlamaDeployClient(ControlPlaneConfig(), timeout=10)
+
+    # sanity check
+    sessions = await client.list_sessions()
+    assert len(sessions) == 0, "Sessions list is not empty"
+
+    # create a session
+    session = await client.create_session()
+
+    # kick off run
+    task_id = await session.run_nowait("hitl_workflow")
+
+    # send event
+    await session.send_event(
+        ev=HumanResponseEvent(response="42"),
+        service_name="hitl_workflow",
+        task_id=task_id,
+    )
+
+    # get final result, polling to wait for workflow to finish after send event
+    final_result = None
+    while final_result is None:
+        final_result = await session.get_task_result(task_id)
+        asyncio.sleep(0.1)
+    assert final_result.result == "42", "The human's response is not consistent."
+
+    # delete the session
+    await client.delete_session(session.session_id)
+    sessions = await client.list_sessions()
+    assert len(sessions) == 0, "Sessions list is not empty"

--- a/e2e_tests/basic_hitl/workflow.py
+++ b/e2e_tests/basic_hitl/workflow.py
@@ -1,0 +1,20 @@
+from llama_index.core.workflow import (
+    StartEvent,
+    StopEvent,
+    Workflow,
+    step,
+)
+from llama_index.core.workflow.events import (
+    HumanResponseEvent,
+    InputRequiredEvent,
+)
+
+
+class HumanInTheLoopWorkflow(Workflow):
+    @step
+    async def step1(self, ev: StartEvent) -> InputRequiredEvent:
+        return InputRequiredEvent(prefix="Enter a number: ")
+
+    @step
+    async def step2(self, ev: HumanResponseEvent) -> StopEvent:
+        return StopEvent(result=ev.response)

--- a/llama_deploy/client/async_client.py
+++ b/llama_deploy/client/async_client.py
@@ -14,7 +14,7 @@ from llama_deploy.types import (
     TaskResult,
 )
 from llama_index.core.workflow import Event
-from llama_index.core.workflow.utils import JsonSerializer
+from llama_index.core.workflow.context_serializers import JsonSerializer
 
 DEFAULT_TIMEOUT = 120.0
 DEFAULT_POLL_INTERVAL = 0.5
@@ -152,7 +152,7 @@ class AsyncSessionClient:
                         f"Task result not available after waiting for {self.timeout} seconds"
                     )
 
-    async def send_event(self, task_id: str, ev: Event) -> None:
+    async def send_event(self, service_name: str, task_id: str, ev: Event) -> None:
         """Send event to a Workflow service.
 
         Args:
@@ -162,7 +162,9 @@ class AsyncSessionClient:
             None
         """
         serializer = JsonSerializer()
-        event_def = EventDefinition(event_obj_str=serializer.serialize(ev))
+        event_def = EventDefinition(
+            event_obj_str=serializer.serialize(ev), agent_id=service_name
+        )
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             await client.post(

--- a/llama_deploy/control_plane/server.py
+++ b/llama_deploy/control_plane/server.py
@@ -592,10 +592,17 @@ class ControlPlaneServer(BaseControlPlane):
         )
 
     async def send_event(
-        self, session_id: str, task_id: str, event_def: EventDefinition
+        self,
+        session_id: str,
+        task_id: str,
+        event_def: EventDefinition,
     ) -> None:
         task_def = TaskDefinition(
-            task_id=task_id, session_id=session_id, input=event_def.event_obj_str
+            task_id=task_id,
+            session_id=session_id,
+            input=event_def.event_obj_str,
+            agent_id=event_def.agent_id,
+            is_send_event=True,
         )
         await self.send_task_to_service(task_def)
 

--- a/llama_deploy/control_plane/server.py
+++ b/llama_deploy/control_plane/server.py
@@ -602,9 +602,13 @@ class ControlPlaneServer(BaseControlPlane):
             session_id=session_id,
             input=event_def.event_obj_str,
             agent_id=event_def.agent_id,
-            is_send_event=True,
         )
-        await self.send_task_to_service(task_def)
+        message = QueueMessage(
+            type=event_def.agent_id,
+            action=ActionTypes.SEND_EVENT,
+            data=task_def.model_dump(),
+        )
+        await self.publish(message)
 
     async def get_session_state(self, session_id: str) -> Dict[str, Any]:
         session = await self.get_session(session_id)

--- a/llama_deploy/control_plane/server.py
+++ b/llama_deploy/control_plane/server.py
@@ -25,6 +25,7 @@ from llama_deploy.orchestrators.base import BaseOrchestrator
 from llama_deploy.orchestrators.utils import get_result_key, get_stream_key
 from llama_deploy.types import (
     ActionTypes,
+    EventDefinition,
     ServiceDefinition,
     SessionDefinition,
     TaskDefinition,
@@ -235,6 +236,12 @@ class ControlPlaneServer(BaseControlPlane):
             "/sessions/{session_id}/tasks/{task_id}/result_stream",
             self.get_task_result_stream,
             methods=["GET"],
+            tags=["Sessions"],
+        )
+        self.app.add_api_route(
+            "/sessions/{session_id}/tasks/{task_id}/send_event",
+            self.send_event,
+            methods=["POST"],
             tags=["Sessions"],
         )
         self.app.add_api_route(
@@ -583,6 +590,14 @@ class ControlPlaneServer(BaseControlPlane):
             event_generator(session, stream_key),
             media_type="application/x-ndjson",
         )
+
+    async def send_event(
+        self, session_id: str, task_id: str, event_def: EventDefinition
+    ) -> None:
+        task_def = TaskDefinition(
+            task_id=task_id, session_id=session_id, input=event_def.event_obj_str
+        )
+        await self.send_task_to_service(task_def)
 
     async def get_session_state(self, session_id: str) -> Dict[str, Any]:
         session = await self.get_session(session_id)

--- a/llama_deploy/services/workflow.py
+++ b/llama_deploy/services/workflow.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import AsyncGenerator, Dict, Optional, Any
 
 from llama_index.core.workflow import Context, Workflow
+from llama_index.core.workflow.handler import WorkflowHandler
 from llama_index.core.workflow.context_serializers import (
     JsonPickleSerializer,
     JsonSerializer,
@@ -294,7 +295,12 @@ class WorkflowService(BaseService):
             # create send_event background task
             close_send_events = asyncio.Event()
 
-            async def send_events(handler: Any, close_event: asyncio.Event) -> None:
+            async def send_events(
+                handler: WorkflowHandler, close_event: asyncio.Event
+            ) -> None:
+                if handler.ctx is None:
+                    raise ValueError("handler does not have a valid Context.")
+
                 while not close_event.is_set():
                     try:
                         event = self._events_buffer[current_call.task_id].get_nowait()

--- a/llama_deploy/services/workflow.py
+++ b/llama_deploy/services/workflow.py
@@ -427,23 +427,22 @@ class WorkflowService(BaseService):
         if message.action == ActionTypes.NEW_TASK:
             task_def = TaskDefinition(**message.data or {})
 
-            if not task_def.is_send_event:
-                run_kwargs = json.loads(task_def.input)
-                workflow_state = WorkflowState(
-                    session_id=task_def.session_id,
-                    task_id=task_def.task_id,
-                    run_kwargs=run_kwargs,
-                )
+            run_kwargs = json.loads(task_def.input)
+            workflow_state = WorkflowState(
+                session_id=task_def.session_id,
+                task_id=task_def.task_id,
+                run_kwargs=run_kwargs,
+            )
 
-                async with self.lock:
-                    self._outstanding_calls[task_def.task_id] = workflow_state
-            else:
-                serializer = JsonSerializer()
+            async with self.lock:
+                self._outstanding_calls[task_def.task_id] = workflow_state
+        elif message.action == ActionTypes.SEND_EVENT:
+            serializer = JsonSerializer()
 
-                task_def = TaskDefinition(**message.data or {})
-                event = serializer.deserialize(task_def.input)
-                async with self.lock:
-                    self._events_buffer[task_def.task_id][type(event)].put_nowait(event)
+            task_def = TaskDefinition(**message.data or {})
+            event = serializer.deserialize(task_def.input)
+            async with self.lock:
+                self._events_buffer[task_def.task_id][type(event)].put_nowait(event)
 
         else:
             raise ValueError(f"Unhandled action: {message.action}")

--- a/llama_deploy/types.py
+++ b/llama_deploy/types.py
@@ -78,6 +78,7 @@ class ActionTypes(str, Enum):
     NEW_TOOL_CALL = "new_tool_call"
     COMPLETED_TOOL_CALL = "completed_tool_call"
     TASK_STREAM = "task_stream"
+    SEND_EVENT = "send_event"
 
 
 class TaskDefinition(BaseModel):
@@ -100,7 +101,6 @@ class TaskDefinition(BaseModel):
     task_id: str = Field(default_factory=generate_id)
     session_id: Optional[str] = None
     agent_id: Optional[str] = None
-    is_send_event: bool = False
 
 
 class SessionDefinition(BaseModel):

--- a/llama_deploy/types.py
+++ b/llama_deploy/types.py
@@ -78,6 +78,7 @@ class ActionTypes(str, Enum):
     NEW_TOOL_CALL = "new_tool_call"
     COMPLETED_TOOL_CALL = "completed_tool_call"
     TASK_STREAM = "task_stream"
+    SEND_EVENT = "send_event"
 
 
 class TaskDefinition(BaseModel):
@@ -125,6 +126,19 @@ class SessionDefinition(BaseModel):
             return None
 
         return self.task_ids[-1]
+
+
+class EventDefinition(BaseModel):
+    """The definition of event.
+
+    To be used as payloads for service endpoints when wanting to send serialized
+    Events.
+
+    Attributes:
+        event_object_str (str): serialized string of event.
+    """
+
+    event_obj_str: str
 
 
 class TaskResult(BaseModel):

--- a/llama_deploy/types.py
+++ b/llama_deploy/types.py
@@ -78,7 +78,6 @@ class ActionTypes(str, Enum):
     NEW_TOOL_CALL = "new_tool_call"
     COMPLETED_TOOL_CALL = "completed_tool_call"
     TASK_STREAM = "task_stream"
-    SEND_EVENT = "send_event"
 
 
 class TaskDefinition(BaseModel):
@@ -101,6 +100,7 @@ class TaskDefinition(BaseModel):
     task_id: str = Field(default_factory=generate_id)
     session_id: Optional[str] = None
     agent_id: Optional[str] = None
+    is_send_event: bool = False
 
 
 class SessionDefinition(BaseModel):
@@ -138,6 +138,7 @@ class EventDefinition(BaseModel):
         event_object_str (str): serialized string of event.
     """
 
+    agent_id: str
     event_obj_str: str
 
 

--- a/tests/services/test_workflow_service.py
+++ b/tests/services/test_workflow_service.py
@@ -4,6 +4,8 @@ import pytest
 from pydantic import PrivateAttr
 from typing import Any, List
 from llama_index.core.workflow import Workflow, StartEvent, StopEvent, step
+from llama_index.core.workflow.events import HumanResponseEvent, InputRequiredEvent
+from llama_index.core.workflow.context_serializers import JsonSerializer
 
 from llama_deploy.messages import QueueMessage
 from llama_deploy.message_consumers import BaseMessageQueueConsumer
@@ -38,6 +40,20 @@ def test_workflow() -> Workflow:
             return StopEvent(result=str(arg1) + "_result")
 
     return TestWorklow()
+
+
+@pytest.fixture()
+def test_hitl_workflow() -> Workflow:
+    class TestHumanInTheLoopWorklow(Workflow):
+        @step
+        async def step1(self, ev: StartEvent) -> InputRequiredEvent:
+            return InputRequiredEvent(prefix="Enter a number: ")
+
+        @step
+        async def step2(self, ev: HumanResponseEvent) -> StopEvent:
+            return StopEvent(result=ev.response)
+
+    return TestHumanInTheLoopWorklow()
 
 
 @pytest.mark.asyncio
@@ -83,3 +99,66 @@ async def test_workflow_service(
     result = human_output_consumer.processed_messages[-1]
     assert result.action == ActionTypes.COMPLETED_TASK
     assert result.data["result"] == "test_arg1_result"
+
+
+@pytest.mark.asyncio()
+async def test_hitl_workflow_service(
+    test_hitl_workflow: Workflow,
+    human_output_consumer: MockMessageConsumer,
+) -> None:
+    # arrange
+    message_queue = SimpleMessageQueue()
+    _ = await message_queue.register_consumer(human_output_consumer)
+
+    # create the service
+    workflow_service = WorkflowService(
+        test_hitl_workflow,
+        message_queue,
+        service_name="test_workflow",
+        description="Test Workflow Service",
+        host="localhost",
+        port=8001,
+    )
+
+    # launch it
+    mq_task = await message_queue.launch_local()
+    server_task = await workflow_service.launch_local()
+
+    # process run task
+    task = TaskDefinition(
+        task_id="1",
+        input=json.dumps({}),
+        session_id="test_session_id",
+    )
+
+    await workflow_service.process_message(
+        QueueMessage(
+            action=ActionTypes.NEW_TASK,
+            data=task.model_dump(),
+        )
+    )
+
+    # process human response event task
+    serializer = JsonSerializer()
+    ev = HumanResponseEvent(response="42")
+    task = TaskDefinition(
+        task_id="1",
+        session_id="test_session_id",
+        input=serializer.serialize(ev),
+    )
+    await workflow_service.process_message(
+        QueueMessage(
+            action=ActionTypes.SEND_EVENT,
+            data=task.model_dump(),
+        )
+    )
+
+    # give time to process and shutdown afterwards
+    await asyncio.sleep(1)
+    mq_task.cancel()
+    server_task.cancel()
+
+    # assert
+    result = human_output_consumer.processed_messages[-1]
+    assert result.action == ActionTypes.COMPLETED_TASK
+    assert result.data["result"] == "42"


### PR DESCRIPTION
With current implementation:

- User sends event via `client.send_event(task_id, session_id, event_def)`
- EventDefinition contains `event_obj_str` which is serialized representation of event as well as `agent_id`
- Within the execution of the Workflow, that is under `WorkflowService.process_call` a background asyncio Task is spawned that deals with passing events to the Workflow.

Testing:
- a new e2e test is added
- a new unit test to workflow_service has been added
