### PR TITLE
feat: Add `services` registration API to `Client`

### DIFF
--- a/e2e_tests/basic_hitl/conftest.py
+++ b/e2e_tests/basic_hitl/conftest.py
@@ -27,7 +27,7 @@ def run_async_workflow():
     )
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture
 def services(core):
     p = multiprocessing.Process(target=run_async_workflow)
     p.start()

--- a/e2e_tests/basic_hitl/conftest.py
+++ b/e2e_tests/basic_hitl/conftest.py
@@ -6,28 +6,11 @@ import pytest
 
 from llama_deploy import (
     ControlPlaneConfig,
-    SimpleMessageQueueConfig,
     WorkflowServiceConfig,
-    deploy_core,
     deploy_workflow,
 )
 
 from .workflow import HumanInTheLoopWorkflow
-
-
-def run_async_core():
-    asyncio.run(deploy_core(ControlPlaneConfig(), SimpleMessageQueueConfig()))
-
-
-@pytest.fixture(scope="package")
-def core():
-    p = multiprocessing.Process(target=run_async_core)
-    p.start()
-    time.sleep(5)
-
-    yield
-
-    p.kill()
 
 
 def run_async_workflow():

--- a/e2e_tests/basic_session/conftest.py
+++ b/e2e_tests/basic_session/conftest.py
@@ -6,28 +6,11 @@ import pytest
 
 from llama_deploy import (
     ControlPlaneConfig,
-    SimpleMessageQueueConfig,
     WorkflowServiceConfig,
-    deploy_core,
     deploy_workflow,
 )
 
 from .workflow import SessionWorkflow
-
-
-def run_async_core():
-    asyncio.run(deploy_core(ControlPlaneConfig(), SimpleMessageQueueConfig()))
-
-
-@pytest.fixture(scope="package")
-def core():
-    p = multiprocessing.Process(target=run_async_core)
-    p.start()
-    time.sleep(5)
-
-    yield
-
-    p.kill()
 
 
 def run_async_workflow():

--- a/e2e_tests/basic_session/conftest.py
+++ b/e2e_tests/basic_session/conftest.py
@@ -27,7 +27,7 @@ def run_async_workflow():
     )
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture
 def workflow(core):
     p = multiprocessing.Process(target=run_async_workflow)
     p.start()

--- a/e2e_tests/basic_streaming/conftest.py
+++ b/e2e_tests/basic_streaming/conftest.py
@@ -27,7 +27,7 @@ def run_async_workflow():
     )
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture
 def services(core):
     p = multiprocessing.Process(target=run_async_workflow)
     p.start()

--- a/e2e_tests/basic_streaming/conftest.py
+++ b/e2e_tests/basic_streaming/conftest.py
@@ -6,28 +6,11 @@ import pytest
 
 from llama_deploy import (
     ControlPlaneConfig,
-    SimpleMessageQueueConfig,
     WorkflowServiceConfig,
-    deploy_core,
     deploy_workflow,
 )
 
 from .workflow import StreamingWorkflow
-
-
-def run_async_core():
-    asyncio.run(deploy_core(ControlPlaneConfig(), SimpleMessageQueueConfig()))
-
-
-@pytest.fixture(scope="package")
-def core():
-    p = multiprocessing.Process(target=run_async_core)
-    p.start()
-    time.sleep(5)
-
-    yield
-
-    p.kill()
 
 
 def run_async_workflow():

--- a/e2e_tests/basic_workflow/conftest.py
+++ b/e2e_tests/basic_workflow/conftest.py
@@ -6,28 +6,11 @@ import pytest
 
 from llama_deploy import (
     ControlPlaneConfig,
-    SimpleMessageQueueConfig,
     WorkflowServiceConfig,
-    deploy_core,
     deploy_workflow,
 )
 
 from .workflow import OuterWorkflow
-
-
-def run_async_core():
-    asyncio.run(deploy_core(ControlPlaneConfig(), SimpleMessageQueueConfig()))
-
-
-@pytest.fixture(scope="package")
-def core():
-    p = multiprocessing.Process(target=run_async_core)
-    p.start()
-    time.sleep(5)
-
-    yield
-
-    p.kill()
 
 
 def run_async_workflow():

--- a/e2e_tests/basic_workflow/conftest.py
+++ b/e2e_tests/basic_workflow/conftest.py
@@ -27,7 +27,7 @@ def run_async_workflow():
     )
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture
 def workflow(core):
     p = multiprocessing.Process(target=run_async_workflow)
     p.start()

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -1,0 +1,23 @@
+import asyncio
+import multiprocessing
+import time
+
+import pytest
+
+from llama_deploy import ControlPlaneConfig, SimpleMessageQueueConfig
+from llama_deploy.deploy import deploy_core
+
+
+def run_async_core():
+    asyncio.run(deploy_core(ControlPlaneConfig(), SimpleMessageQueueConfig()))
+
+
+@pytest.fixture(scope="package")
+def core():
+    p = multiprocessing.Process(target=run_async_core)
+    p.start()
+    time.sleep(5)
+
+    yield
+
+    p.kill()

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -12,11 +12,11 @@ def run_async_core():
     asyncio.run(deploy_core(ControlPlaneConfig(), SimpleMessageQueueConfig()))
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture
 def core():
     p = multiprocessing.Process(target=run_async_core)
     p.start()
-    time.sleep(5)
+    time.sleep(3)
 
     yield
 

--- a/e2e_tests/core/conftest.py
+++ b/e2e_tests/core/conftest.py
@@ -1,0 +1,38 @@
+import asyncio
+import multiprocessing
+import time
+
+import pytest
+
+from llama_deploy import (
+    ControlPlaneConfig,
+    WorkflowServiceConfig,
+    deploy_workflow,
+)
+
+from .workflow import BasicWorkflow
+
+
+def run_async_workflow():
+    asyncio.run(
+        deploy_workflow(
+            BasicWorkflow(timeout=10),
+            WorkflowServiceConfig(
+                host="127.0.0.1",
+                port=8002,
+                service_name="basic",
+            ),
+            ControlPlaneConfig(),
+        )
+    )
+
+
+@pytest.fixture
+def workflow(core):
+    p = multiprocessing.Process(target=run_async_workflow)
+    p.start()
+    time.sleep(5)
+
+    yield
+
+    p.kill()

--- a/e2e_tests/core/test_services.py
+++ b/e2e_tests/core/test_services.py
@@ -1,0 +1,39 @@
+import pytest
+
+from llama_deploy import Client
+from llama_deploy.types.core import ServiceDefinition
+
+
+@pytest.mark.e2e
+def test_services(workflow):
+    client = Client()
+
+    services = client.sync.core.services()
+    assert len(services.items) == 1
+
+    services.deregister("basic")
+    assert len(services.items) == 0
+
+    new_s = services.register(
+        ServiceDefinition(service_name="another_basic", description="none")
+    )
+    assert new_s.id == "another_basic"
+    assert len(services.items) == 1
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_services_async(workflow):
+    client = Client()
+
+    services = await client.core.services()
+    assert len(services.items) == 1
+
+    await services.deregister("basic")
+    assert len(services.items) == 0
+
+    new_s = await services.register(
+        ServiceDefinition(service_name="another_basic", description="none")
+    )
+    assert new_s.id == "another_basic"
+    assert len(services.items) == 1

--- a/e2e_tests/core/workflow.py
+++ b/e2e_tests/core/workflow.py
@@ -1,0 +1,11 @@
+from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
+
+
+class BasicWorkflow(Workflow):
+    @step()
+    async def run_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
+        arg1 = ev.get("arg1")
+        if not arg1:
+            raise ValueError("arg1 is required.")
+
+        return StopEvent(result=str(arg1) + "_result")

--- a/llama_deploy/client/base.py
+++ b/llama_deploy/client/base.py
@@ -14,16 +14,18 @@ class _BaseClient(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="LLAMA_DEPLOY_")
 
     api_server_url: str = "http://localhost:4501"
+    control_plane_url: str = "http://localhost:8000"
     disable_ssl: bool = False
     timeout: float = 120.0
     poll_interval: float = 0.5
 
     async def request(
-        self, method: str, url: str | httpx.URL, *args: Any, **kwargs: Any
+        self, method: str, url: str | httpx.URL, **kwargs: Any
     ) -> httpx.Response:
         """Performs an async HTTP request using httpx."""
         verify = kwargs.pop("verify", True)
+        timeout = kwargs.pop("timeout", self.timeout)
         async with httpx.AsyncClient(verify=verify) as client:
-            response = await client.request(method, url, *args, **kwargs)
+            response = await client.request(method, url, timeout=timeout, **kwargs)
             response.raise_for_status()
             return response

--- a/llama_deploy/client/client.py
+++ b/llama_deploy/client/client.py
@@ -1,5 +1,5 @@
 from .base import _BaseClient
-from .models import ApiServer
+from .models import ApiServer, Core
 
 
 class Client(_BaseClient):
@@ -32,6 +32,11 @@ class Client(_BaseClient):
     def apiserver(self) -> ApiServer:
         """Returns the ApiServer model."""
         return ApiServer.instance(client=self, id="apiserver")
+
+    @property
+    def core(self) -> Core:
+        """Returns the Core model."""
+        return Core.instance(client=self, id="core")
 
 
 class _SyncClient(Client):

--- a/llama_deploy/client/client.py
+++ b/llama_deploy/client/client.py
@@ -24,7 +24,7 @@ class Client(_BaseClient):
     """
 
     @property
-    def sync(self) -> "Client":
+    def sync(self) -> "_SyncClient":
         """Returns the sync version of the client API."""
         return _SyncClient(**self.model_dump())
 
@@ -43,3 +43,7 @@ class _SyncClient(Client):
     @property
     def apiserver(self) -> ApiServer:
         return ApiServer.instance(make_sync=True, client=self, id="apiserver")
+
+    @property
+    def core(self) -> Core:
+        return Core.instance(make_sync=True, client=self, id="core")

--- a/llama_deploy/client/models/__init__.py
+++ b/llama_deploy/client/models/__init__.py
@@ -1,4 +1,5 @@
 from .apiserver import ApiServer
+from .core import Core
 from .model import Collection, Model
 
-__all__ = ["ApiServer", "Collection", "Model"]
+__all__ = ["ApiServer", "Collection", "Core", "Model"]

--- a/llama_deploy/client/models/core.py
+++ b/llama_deploy/client/models/core.py
@@ -1,0 +1,46 @@
+from llama_deploy.types.core import ServiceDefinition
+
+from .model import Collection, Model
+
+
+class Service(Model):
+    pass
+
+
+class ServiceCollection(Collection):
+    async def register(self, service: ServiceDefinition) -> None:
+        """Registers a service with the control plane.
+
+        Args:
+            service: Definition of the Service to register.
+        """
+        register_url = f"{self.client.control_plane_url}/services/register"
+        await self.client.request("POST", register_url, json=service.model_dump())
+
+    async def deregister(self, service_name: str) -> None:
+        """Deregisters a service from the control plane.
+
+        Args:
+            service_name: The name of the Service to deregister.
+        """
+        deregister_url = f"{self.client.control_plane_url}/services/deregister"
+        await self.client.request(
+            "POST",
+            deregister_url,
+            json={"service_name": service_name},
+        )
+
+
+class Core(Model):
+    async def services(self) -> ServiceCollection:
+        """Returns a collection containing all the services registered with the control plane.
+
+        Returns:
+            ServiceCollection: Collection of services registered with the control plane.
+        """
+        services_url = f"{self.client.control_plane_url}/services"
+        response = await self.client.request("GET", services_url)
+        items = {}
+        for name, service in response.json().items():
+            items["name"] = Service.instance(client=self.client, id=name)
+        return ServiceCollection.instance(client=self.client, items=items)

--- a/tests/client/models/test_core.py
+++ b/tests/client/models/test_core.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+import pytest
+
+from llama_deploy.client.models.core import Core, Service, ServiceCollection
+from llama_deploy.types.core import ServiceDefinition
+
+
+@pytest.mark.asyncio
+async def test_service_collection_register(client: mock.AsyncMock) -> None:
+    coll = ServiceCollection.instance(client=client, items={})
+    service = ServiceDefinition(service_name="test_service", description="some service")
+    await coll.register(service)
+
+    client.request.assert_awaited_with(
+        "POST",
+        "http://localhost:8000/services/register",
+        json={
+            "service_name": "test_service",
+            "description": "some service",
+            "prompt": [],
+            "host": None,
+            "port": None,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_collection_deregister(client: mock.AsyncMock) -> None:
+    coll = ServiceCollection.instance(client=client, items={})
+    await coll.deregister("test_service")
+
+    client.request.assert_awaited_with(
+        "POST",
+        "http://localhost:8000/services/deregister",
+        json={"service_name": "test_service"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_core_services(client: mock.AsyncMock) -> None:
+    client.request.return_value = mock.MagicMock(
+        json=lambda: {"test_service": {"name": "test_service"}}
+    )
+
+    core = Core.instance(client=client, id="core")
+    services = await core.services()
+
+    client.request.assert_awaited_with("GET", "http://localhost:8000/services")
+    assert isinstance(services, ServiceCollection)
+    assert "name" in services.items
+    assert isinstance(services.items["name"], Service)

--- a/tests/client/models/test_core.py
+++ b/tests/client/models/test_core.py
@@ -27,13 +27,16 @@ async def test_service_collection_register(client: mock.AsyncMock) -> None:
 
 @pytest.mark.asyncio
 async def test_service_collection_deregister(client: mock.AsyncMock) -> None:
-    coll = ServiceCollection.instance(client=client, items={})
+    coll = ServiceCollection.instance(
+        client=client,
+        items={"test_service": Service.instance(client=client, id="test_service")},
+    )
     await coll.deregister("test_service")
 
     client.request.assert_awaited_with(
         "POST",
         "http://localhost:8000/services/deregister",
-        json={"service_name": "test_service"},
+        params={"service_name": "test_service"},
     )
 
 
@@ -48,5 +51,5 @@ async def test_core_services(client: mock.AsyncMock) -> None:
 
     client.request.assert_awaited_with("GET", "http://localhost:8000/services")
     assert isinstance(services, ServiceCollection)
-    assert "name" in services.items
-    assert isinstance(services.items["name"], Service)
+    assert "test_service" in services.items
+    assert isinstance(services.items["test_service"], Service)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -4,7 +4,7 @@ import pytest
 
 from llama_deploy.client import Client
 from llama_deploy.client.client import _SyncClient
-from llama_deploy.client.models.apiserver import ApiServer
+from llama_deploy.client.models import ApiServer, Core
 
 
 def test_client_init_default() -> None:
@@ -33,7 +33,9 @@ def test_client_sync() -> None:
 def test_client_attributes() -> None:
     c = Client()
     assert type(c.apiserver) is ApiServer
+    assert type(c.core) is Core
     assert issubclass(type(c.sync.apiserver), ApiServer)
+    assert issubclass(type(c.sync.core), Core)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of #335

- Added `client.core.services`

Also in this PR:
- remove the need to pass `timeout` to the client every single request. It can still be passed if one needs a custom value.
- move common fixtures to global `conftest.py` to reduce duplication
- removed `scope=session` so every e2e function has a fresh control plane to test