### PR TITLE
feat: Migrate e2e test `basic_workflow` to new Client and port missing features from old client

### DIFF
--- a/e2e_tests/basic_workflow/test_run_client.py
+++ b/e2e_tests/basic_workflow/test_run_client.py
@@ -1,27 +1,21 @@
 import pytest
 
-from llama_deploy import AsyncLlamaDeployClient, ControlPlaneConfig, LlamaDeployClient
+from llama_deploy import Client
 
 
 @pytest.mark.e2e
 def test_run_client(workflow):
-    client = LlamaDeployClient(ControlPlaneConfig(), timeout=10)
+    client = Client(timeout=10)
 
     # test connections
-    assert (
-        len(client.list_services()) == 1
-    ), f"Expected 1 service, got {client.list_services()}"
-    assert (
-        len(client.list_sessions()) == 0
-    ), f"Expected 0 sessions, got {client.list_sessions()}"
+    assert len(client.sync.core.services.list()) == 1
+    assert len(client.sync.core.sessions.list()) == 0
 
     # test create session
-    session = client.get_or_create_session("fake_session_id")
-    sessions = client.list_sessions()
-    assert len(sessions) == 1, f"Expected 1 session, got {sessions}"
-    assert (
-        sessions[0].session_id == session.session_id
-    ), f"Expected session id to be {session.session_id}, got {sessions[0].session_id}"
+    session = client.sync.core.sessions.get_or_create("fake_session_id")
+    sessions = client.sync.core.sessions.list()
+    assert len(sessions) == 1
+    assert sessions[0].id == session.id
 
     # test run with session
     result = session.run("outer", arg1="hello_world")
@@ -29,38 +23,28 @@ def test_run_client(workflow):
 
     # test number of tasks
     tasks = session.get_tasks()
-    assert len(tasks) == 1, f"Expected 1 task, got {len(tasks)} tasks"
-    assert (
-        tasks[0].agent_id == "outer"
-    ), f"Expected id to be 'outer', got {tasks[0].agent_id}"
+    assert len(tasks) == 1
+    assert tasks[0].agent_id == "outer"
 
     # delete everything
-    client.delete_session(session.session_id)
-    assert (
-        len(client.list_sessions()) == 0
-    ), f"Expected 0 sessions, got {client.list_sessions()}"
+    client.sync.core.sessions.delete(session.id)
+    assert len(client.sync.core.sessions.list()) == 0
 
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_run_client_async(workflow):
-    client = AsyncLlamaDeployClient(ControlPlaneConfig(), timeout=10)
+    client = Client(timeout=10)
 
     # test connections
-    assert (
-        len(await client.list_services()) == 1
-    ), f"Expected 1 service, got {await client.list_services()}"
-    assert (
-        len(await client.list_sessions()) == 0
-    ), f"Expected 0 sessions, got {await client.list_sessions()}"
+    assert len(await client.core.services.list()) == 1
+    assert len(await client.core.sessions.list()) == 0
 
     # test create session
-    session = await client.get_or_create_session("fake_session_id")
-    sessions = await client.list_sessions()
+    session = await client.core.sessions.get_or_create("fake_session_id")
+    sessions = await client.core.sessions.list()
     assert len(sessions) == 1, f"Expected 1 session, got {sessions}"
-    assert (
-        sessions[0].session_id == session.session_id
-    ), f"Expected session id to be {session.session_id}, got {sessions[0].session_id}"
+    assert sessions[0].id == session.id
 
     # test run with session
     result = await session.run("outer", arg1="hello_world")
@@ -74,7 +58,5 @@ async def test_run_client_async(workflow):
     ), f"Expected id to be 'outer', got {tasks[0].agent_id}"
 
     # delete everything
-    await client.delete_session(session.session_id)
-    assert (
-        len(await client.list_sessions()) == 0
-    ), f"Expected 0 sessions, got {await client.list_sessions()}"
+    await client.core.sessions.delete(session.id)
+    assert len(await client.core.sessions.list()) == 0

--- a/e2e_tests/core/test_services.py
+++ b/e2e_tests/core/test_services.py
@@ -28,7 +28,7 @@ async def test_services_async(workflow):
 
     assert len(await client.core.services.list()) == 1
     await client.core.services.deregister("basic")
-    assert len(await client.core.services.list()) == 1
+    assert len(await client.core.services.list()) == 0
 
     new_s = await client.core.services.register(
         ServiceDefinition(service_name="another_basic", description="none")

--- a/e2e_tests/core/test_services.py
+++ b/e2e_tests/core/test_services.py
@@ -8,8 +8,8 @@ from llama_deploy.types.core import ServiceDefinition
 def test_services(workflow):
     client = Client()
 
-    services = client.sync.core.services()
-    assert len(services.items) == 1
+    services = client.sync.core.services
+    assert len(services.list()) == 1
 
     services.deregister("basic")
     assert len(services.items) == 0
@@ -26,14 +26,12 @@ def test_services(workflow):
 async def test_services_async(workflow):
     client = Client()
 
-    services = await client.core.services()
-    assert len(services.items) == 1
+    assert len(await client.core.services.list()) == 1
+    await client.core.services.deregister("basic")
+    assert len(await client.core.services.list()) == 1
 
-    await services.deregister("basic")
-    assert len(services.items) == 0
-
-    new_s = await services.register(
+    new_s = await client.core.services.register(
         ServiceDefinition(service_name="another_basic", description="none")
     )
     assert new_s.id == "another_basic"
-    assert len(services.items) == 1
+    assert len(await client.core.services.list()) == 1

--- a/llama_deploy/client/models/core.py
+++ b/llama_deploy/client/models/core.py
@@ -200,7 +200,6 @@ class ServiceCollection(Collection):
             deregister_url,
             params={"service_name": service_name},
         )
-        self.items.pop(service_name)
 
 
 class Core(Model):


### PR DESCRIPTION
Part of #335 

Also in this PR:
- implement the same strategy of "lazy connections" we introduced for `SessionCollection` to `ServiceCollection`. This way we can expose `client.core.services` as a property and save one `await`.