### PR TITLE
refact: make collections in apiserver models lazy

### DIFF
--- a/e2e_tests/apiserver/test_deploy.py
+++ b/e2e_tests/apiserver/test_deploy.py
@@ -6,9 +6,8 @@ import pytest
 @pytest.mark.asyncio
 async def test_deploy(apiserver, client):
     here = Path(__file__).parent
-    deployments = await client.apiserver.deployments()
     with open(here / "deployments" / "deployment1.yml") as f:
-        await deployments.create(f)
+        await client.apiserver.deployments.create(f)
 
     status = await client.apiserver.status()
     assert "TestDeployment1" in status.deployments
@@ -16,8 +15,7 @@ async def test_deploy(apiserver, client):
 
 def test_deploy_sync(apiserver, client):
     here = Path(__file__).parent
-    deployments = client.sync.apiserver.deployments()
     with open(here / "deployments" / "deployment2.yml") as f:
-        deployments.create(f)
+        client.sync.apiserver.deployments.create(f)
 
     assert "TestDeployment2" in client.sync.apiserver.status().deployments

--- a/e2e_tests/apiserver/test_status.py
+++ b/e2e_tests/apiserver/test_status.py
@@ -14,7 +14,7 @@ def test_status_down_sync(client):
 
 @pytest.mark.asyncio
 async def test_status_up(apiserver, client):
-    res = await client.sync.apiserver.status()
+    res = await client.apiserver.status()
     assert res.status.value == "Healthy"
 
 

--- a/tests/client/models/test_apiserver.py
+++ b/tests/client/models/test_apiserver.py
@@ -147,7 +147,7 @@ async def test_task_deployment_tasks(client: Any) -> None:
     ]
     client.request.return_value = mock.MagicMock(json=lambda: res)
 
-    await d.tasks()
+    await d.tasks.list()
 
     client.request.assert_awaited_with(
         "GET",
@@ -163,7 +163,7 @@ async def test_task_deployment_sessions(client: Any) -> None:
     res: list[SessionDefinition] = [SessionDefinition(session_id="a_session")]
     client.request.return_value = mock.MagicMock(json=lambda: res)
 
-    await d.sessions()
+    await d.sessions.list()
 
     client.request.assert_awaited_with(
         "GET",
@@ -278,7 +278,7 @@ async def test_deployments(client: Any) -> None:
         status_code=200, text="", json=lambda: {"deployments": ["foo", "bar"]}
     )
     apis = ApiServer.instance(client=client, id="apiserver")
-    await apis.deployments()
+    await apis.deployments.list()
     client.request.assert_awaited_with(
         "GET", "http://localhost:4501/deployments/", verify=True, timeout=120.0
     )


### PR DESCRIPTION
Adjust `client.apiserver.deployments` and `client.apiserver.sessions` so that they don't actually load the items in a collection, deferring that to `list`. This way `sessions` and `deployments` can be regular properties, accessible without `await`.
This was originally implemented for the `core` client, this PR makes it consistent with the rest of the models.

Part of #337 