### PR TITLE
feat: add get_task_result_stream to new client

### DIFF
--- a/e2e_tests/basic_streaming/test_run_client.py
+++ b/e2e_tests/basic_streaming/test_run_client.py
@@ -1,23 +1,24 @@
 import pytest
 
-from llama_deploy import AsyncLlamaDeployClient, ControlPlaneConfig, LlamaDeployClient
+from llama_deploy import Client
 
 
 @pytest.mark.e2e
 def test_run_client(services):
-    client = LlamaDeployClient(ControlPlaneConfig(), timeout=10)
+    client = Client(timeout=10)
 
     # sanity check
-    sessions = client.list_sessions()
+    sessions = client.sync.core.sessions.list()
     assert len(sessions) == 0, "Sessions list is not empty"
 
     # test streaming
-    session = client.create_session()
+    session = client.sync.core.sessions.create()
 
     # kick off run
     task_id = session.run_nowait("streaming_workflow", arg1="hello_world")
 
     num_events = 0
+    print("-->", session.get_task_result_stream)
     for event in session.get_task_result_stream(task_id):
         if "progress" in event:
             num_events += 1
@@ -30,27 +31,19 @@ def test_run_client(services):
 
     # get final result
     final_result = session.get_task_result(task_id)
-    assert (
-        final_result.result == "hello_world_result_result_result"  # type: ignore
-    ), "Final result is not 'hello_world_result_result_result'"
+    assert final_result.result == "hello_world_result_result_result"  # type: ignore
 
     # delete everything
-    client.delete_session(session.session_id)
-    sessions = client.list_sessions()
-    assert len(sessions) == 0, "Sessions list is not empty"
+    client.sync.core.sessions.delete(session.id)
 
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_run_client_async(services):
-    client = AsyncLlamaDeployClient(ControlPlaneConfig(), timeout=10)
-
-    # sanity check
-    sessions = await client.list_sessions()
-    assert len(sessions) == 0, "Sessions list is not empty"
+    client = Client(timeout=10)
 
     # test streaming
-    session = await client.create_session()
+    session = await client.core.sessions.create()
 
     # kick off run
     task_id = await session.run_nowait("streaming_workflow", arg1="hello_world")
@@ -67,11 +60,7 @@ async def test_run_client_async(services):
                 assert event["progress"] == 0.9
 
     final_result = await session.get_task_result(task_id)
-    assert (
-        final_result.result == "hello_world_result_result_result"  # type: ignore
-    ), "Final result is not 'hello_world_result_result_result'"
+    assert final_result.result == "hello_world_result_result_result"  # type: ignore
 
     # delete everything
-    await client.delete_session(session.session_id)
-    sessions = await client.list_sessions()
-    assert len(sessions) == 0, "Sessions list is not empty"
+    await client.core.sessions.delete(session.id)

--- a/e2e_tests/basic_streaming/test_run_client.py
+++ b/e2e_tests/basic_streaming/test_run_client.py
@@ -18,7 +18,6 @@ def test_run_client(services):
     task_id = session.run_nowait("streaming_workflow", arg1="hello_world")
 
     num_events = 0
-    print("-->", session.get_task_result_stream)
     for event in session.get_task_result_stream(task_id):
         if "progress" in event:
             num_events += 1

--- a/llama_deploy/client/client.py
+++ b/llama_deploy/client/client.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 from .base import _BaseClient
@@ -28,7 +29,13 @@ class Client(_BaseClient):
     @property
     def sync(self) -> "_SyncClient":
         """Returns the sync version of the client API."""
-        return _SyncClient(**self.model_dump())
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return _SyncClient(**self.model_dump())
+
+        msg = "You cannot use the sync client within an async event loop - just await the async methods directly."
+        raise RuntimeError(msg)
 
     @property
     def apiserver(self) -> ApiServer:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -30,6 +30,16 @@ def test_client_sync() -> None:
     assert sc.poll_interval == 0.5
 
 
+@pytest.mark.asyncio
+async def test_client_sync_within_loop() -> None:
+    c = Client()
+    with pytest.raises(
+        RuntimeError,
+        match="You cannot use the sync client within an async event loop - just await the async methods directly.",
+    ):
+        c.sync
+
+
 def test_client_attributes() -> None:
     c = Client()
     assert type(c.apiserver) is ApiServer


### PR DESCRIPTION
This PR ports the last method missing from `AsyncSessionClient`, `get_task_result_stream`.

Fixes https://github.com/run-llama/llama_deploy/issues/335

Notes for the reviewer:
- async methods returning `Coroutine[AsyncGenerator]` when converted with `async_to_sync` return `AsyncGenerator`, that we can't use in sync calls. To overcome this limitation, `generator_wrapper` was added that consumes the async generator under the hood and returns a list
- end-to-end tests were update to use `Client`
- unit tests were added to cover the new wrapper