### PR TITLE
Use the new SDK within the api server

### DIFF
--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from llama_deploy import (
-    AsyncLlamaDeployClient,
+    Client,
     ControlPlaneServer,
     SimpleMessageQueue,
     SimpleOrchestrator,
@@ -61,7 +61,7 @@ class Deployment:
             config=config.control_plane,
         )
         self._workflow_services: list[WorkflowService] = self._load_services(config)
-        self._client = AsyncLlamaDeployClient(config.control_plane)
+        self._client = Client(control_plane_url=config.control_plane.url)
         self._default_service = config.default_service
 
     @property
@@ -69,7 +69,7 @@ class Deployment:
         return self._default_service
 
     @property
-    def client(self) -> AsyncLlamaDeployClient:
+    def client(self) -> Client:
         """Returns an async client to interact with this deployment."""
         return self._client
 

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -6,7 +6,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from llama_deploy.apiserver.config_parser import Config
 from llama_deploy.apiserver.server import manager
-from llama_deploy.types import TaskDefinition
+from llama_deploy.types import DeploymentDefinition, SessionDefinition, TaskDefinition
+from llama_deploy.types.core import TaskResult
 
 deployments_router = APIRouter(
     prefix="/deployments",
@@ -14,40 +15,29 @@ deployments_router = APIRouter(
 
 
 @deployments_router.get("/")
-async def read_deployments() -> JSONResponse:
+async def read_deployments() -> list[DeploymentDefinition]:
     """Returns a list of active deployments."""
-    return JSONResponse(
-        {
-            "deployments": list(manager._deployments.keys()),
-        }
-    )
+    return [DeploymentDefinition(name=k) for k in manager._deployments.keys()]
 
 
 @deployments_router.get("/{deployment_name}")
-async def read_deployment(deployment_name: str) -> JSONResponse:
+async def read_deployment(deployment_name: str) -> DeploymentDefinition:
     """Returns the details of a specific deployment."""
     if deployment_name not in manager.deployment_names:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
-    return JSONResponse(
-        {
-            f"{deployment_name}": "Up!",
-        }
-    )
+    return DeploymentDefinition(name=deployment_name)
 
 
 @deployments_router.post("/create")
-async def create_deployment(config_file: UploadFile = File(...)) -> JSONResponse:
+async def create_deployment(
+    config_file: UploadFile = File(...),
+) -> DeploymentDefinition:
     """Creates a new deployment by uploading a configuration file."""
     config = Config.from_yaml_bytes(await config_file.read())
     manager.deploy(config)
 
-    # Return some details about the file
-    return JSONResponse(
-        {
-            "name": config.name,
-        }
-    )
+    return DeploymentDefinition(name=config.name)
 
 
 @deployments_router.post("/{deployment_name}/tasks/run")
@@ -67,7 +57,10 @@ async def create_deployment_task(
             )
         task_definition.agent_id = deployment.default_service
 
-    session = await deployment.client.get_or_create_session(session_id or "none")
+    if session_id:
+        session = await deployment.client.core.sessions.get(session_id)
+    else:
+        session = await deployment.client.core.sessions.create()
 
     result = await session.run(
         task_definition.agent_id or "", **json.loads(task_definition.input)
@@ -75,7 +68,7 @@ async def create_deployment_task(
 
     # Assume the request does not care about the session if no session_id is provided
     if session_id is None:
-        await deployment.client.delete_session(session.session_id)
+        await deployment.client.core.sessions.delete(session.id)
 
     return JSONResponse(result)
 
@@ -83,7 +76,7 @@ async def create_deployment_task(
 @deployments_router.post("/{deployment_name}/tasks/create")
 async def create_deployment_task_nowait(
     deployment_name: str, task_definition: TaskDefinition, session_id: str | None = None
-) -> JSONResponse:
+) -> TaskDefinition:
     """Create a task for the deployment but don't wait for result."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
@@ -97,13 +90,17 @@ async def create_deployment_task_nowait(
             )
         task_definition.agent_id = deployment.default_service
 
-    session = await deployment.client.get_or_create_session(session_id or "none")
+    if session_id:
+        session = await deployment.client.core.sessions.get(session_id)
+    else:
+        session = await deployment.client.core.sessions.create()
 
-    task_id = await session.run_nowait(
+    task_definition.session_id = session_id
+    task_definition.task_id = await session.run_nowait(
         task_definition.agent_id or "", **json.loads(task_definition.input)
     )
 
-    return JSONResponse({"session_id": session.session_id, "task_id": task_id})
+    return task_definition
 
 
 @deployments_router.get("/{deployment_name}/tasks/{task_id}/events")
@@ -115,7 +112,7 @@ async def get_events(
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
-    session = await deployment.client.get_session(session_id)
+    session = await deployment.client.core.sessions.get(session_id)
 
     async def event_stream() -> AsyncGenerator[str, None]:
         # need to convert back to str to use SSE
@@ -131,46 +128,43 @@ async def get_events(
 @deployments_router.get("/{deployment_name}/tasks/{task_id}/results")
 async def get_task_result(
     deployment_name: str, session_id: str, task_id: str
-) -> JSONResponse:
+) -> TaskResult | None:
     """Get the task result associated with a task and session."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
-    session = await deployment.client.get_session(session_id)
-    result = await session.get_task_result(task_id)
-
-    return JSONResponse(result.result if result else "")
+    session = await deployment.client.core.sessions.get(session_id)
+    return await session.get_task_result(task_id)
 
 
 @deployments_router.get("/{deployment_name}/tasks")
 async def get_tasks(
     deployment_name: str,
-) -> JSONResponse:
+) -> list[TaskDefinition]:
     """Get all the tasks from all the sessions in a given deployment."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
     tasks: list[TaskDefinition] = []
-    for session_def in await deployment.client.list_sessions():
-        session = await deployment.client.get_session(session_id=session_def.session_id)
+    for session in await deployment.client.core.sessions.list():
         for task_def in await session.get_tasks():
             tasks.append(task_def)
-    return JSONResponse(tasks)
+    return tasks
 
 
 @deployments_router.get("/{deployment_name}/sessions")
 async def get_sessions(
     deployment_name: str,
-) -> JSONResponse:
+) -> list[SessionDefinition]:
     """Get the active sessions in a deployment and service."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
-    sessions = await deployment.client.list_sessions()
-    return JSONResponse(sessions)
+    sessions = await deployment.client.core.sessions.list()
+    return [SessionDefinition(session_id=s.id) for s in sessions]
 
 
 @deployments_router.get("/{deployment_name}/sessions/{session_id}")
@@ -180,7 +174,7 @@ async def get_session(deployment_name: str, session_id: str) -> JSONResponse:
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
-    session = await deployment.client.get_session_definition(session_id)
+    session = await deployment.client.core.sessions.get(session_id)
     return JSONResponse(session.model_dump())
 
 
@@ -191,8 +185,8 @@ async def create_session(deployment_name: str) -> JSONResponse:
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
-    session = await deployment.client.create_session()
-    return JSONResponse({"session_id": session.session_id})
+    session = await deployment.client.core.sessions.create()
+    return JSONResponse({"session_id": session.id})
 
 
 @deployments_router.post("/{deployment_name}/sessions/delete")
@@ -202,5 +196,5 @@ async def delete_session(deployment_name: str, session_id: str) -> JSONResponse:
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
-    await deployment.client.delete_session(session_id)
+    await deployment.client.core.sessions.delete(session_id)
     return JSONResponse({"session_id": session_id, "status": "Deleted"})

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -168,33 +168,32 @@ async def get_sessions(
 
 
 @deployments_router.get("/{deployment_name}/sessions/{session_id}")
-async def get_session(deployment_name: str, session_id: str) -> JSONResponse:
+async def get_session(deployment_name: str, session_id: str) -> SessionDefinition:
     """Get the definition of a session by ID."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
     session = await deployment.client.core.sessions.get(session_id)
-    return JSONResponse(session.model_dump())
+    return SessionDefinition(session_id=session.id)
 
 
 @deployments_router.post("/{deployment_name}/sessions/create")
-async def create_session(deployment_name: str) -> JSONResponse:
+async def create_session(deployment_name: str) -> SessionDefinition:
     """Create a new session for a deployment."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
     session = await deployment.client.core.sessions.create()
-    return JSONResponse({"session_id": session.id})
+    return SessionDefinition(session_id=session.id)
 
 
 @deployments_router.post("/{deployment_name}/sessions/delete")
-async def delete_session(deployment_name: str, session_id: str) -> JSONResponse:
+async def delete_session(deployment_name: str, session_id: str) -> None:
     """Get the active sessions in a deployment and service."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
         raise HTTPException(status_code=404, detail="Deployment not found")
 
     await deployment.client.core.sessions.delete(session_id)
-    return JSONResponse({"session_id": session_id, "status": "Deleted"})

--- a/llama_deploy/apiserver/routers/status.py
+++ b/llama_deploy/apiserver/routers/status.py
@@ -1,8 +1,7 @@
 from fastapi import APIRouter
-from fastapi.responses import JSONResponse
 
 from llama_deploy.apiserver.server import manager
-
+from llama_deploy.types.apiserver import Status, StatusEnum
 
 status_router = APIRouter(
     prefix="/status",
@@ -10,11 +9,10 @@ status_router = APIRouter(
 
 
 @status_router.get("/")
-async def status() -> JSONResponse:
-    return JSONResponse(
-        {
-            "status": "Up!",
-            "max_deployments": manager._max_deployments,
-            "deployments": list(manager._deployments.keys()),
-        }
+async def status() -> Status:
+    return Status(
+        status=StatusEnum.HEALTHY,
+        max_deployments=manager._max_deployments,
+        deployments=list(manager._deployments.keys()),
+        status_message="",
     )

--- a/llama_deploy/types/__init__.py
+++ b/llama_deploy/types/__init__.py
@@ -1,3 +1,4 @@
+from .apiserver import DeploymentDefinition, Status, StatusEnum
 from .core import (
     CONTROL_PLANE_NAME,
     ActionTypes,
@@ -34,4 +35,7 @@ __all__ = [
     "ToolCallBundle",
     "ToolCallResult",
     "generate_id",
+    "DeploymentDefinition",
+    "Status",
+    "StatusEnum",
 ]

--- a/llama_deploy/types/apiserver.py
+++ b/llama_deploy/types/apiserver.py
@@ -14,3 +14,7 @@ class Status(BaseModel):
     status_message: str
     max_deployments: int | None = None
     deployments: list[str] | None = None
+
+
+class DeploymentDefinition(BaseModel):
+    name: str

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -207,5 +207,4 @@ def test_delete_session(http_client: TestClient, data_path: Path) -> None:
             "/deployments/test-deployment/sessions/delete/?session_id=42",
         )
         assert response.status_code == 200
-        assert response.json() == {"session_id": "42", "status": "Deleted"}
         deployment.client.core.sessions.delete.assert_called_with("42")

--- a/tests/apiserver/routers/test_status.py
+++ b/tests/apiserver/routers/test_status.py
@@ -7,5 +7,6 @@ def test_read_main(http_client: TestClient) -> None:
     assert response.json() == {
         "max_deployments": 10,
         "deployments": [],
-        "status": "Up!",
+        "status": "Healthy",
+        "status_message": "",
     }

--- a/tests/client/models/test_apiserver.py
+++ b/tests/client/models/test_apiserver.py
@@ -9,7 +9,6 @@ from llama_deploy.client.models.apiserver import (
     ApiServer,
     Deployment,
     DeploymentCollection,
-    Session,
     SessionCollection,
     Task,
     TaskCollection,
@@ -21,7 +20,7 @@ from llama_deploy.types import SessionDefinition, TaskDefinition, TaskResult
 async def test_session_collection_delete(client: Any) -> None:
     coll = SessionCollection(
         client=client,
-        items={"a_session": Session(id="a_session", client=client)},
+        items={},
         deployment_id="a_deployment",
     )
     await coll.delete("a_session")
@@ -83,9 +82,9 @@ async def test_session_collection_list(client: Any) -> None:
 
     # Verify returned sessions
     assert len(sessions) == 2
-    assert all(isinstance(session, Session) for session in sessions)
-    assert sessions[0].id == "session1"
-    assert sessions[1].id == "session2"
+    assert all(isinstance(session, SessionDefinition) for session in sessions)
+    assert sessions[0].session_id == "session1"
+    assert sessions[1].session_id == "session2"
 
 
 @pytest.mark.asyncio
@@ -182,7 +181,7 @@ async def test_task_deployment_tasks(client: Any) -> None:
     ]
     client.request.return_value = mock.MagicMock(json=lambda: res)
 
-    await d.tasks()
+    await d.tasks.list()
 
     client.request.assert_awaited_with(
         "GET",
@@ -198,7 +197,7 @@ async def test_task_deployment_sessions(client: Any) -> None:
     res: list[SessionDefinition] = [SessionDefinition(session_id="a_session")]
     client.request.return_value = mock.MagicMock(json=lambda: res)
 
-    await d.sessions()
+    await d.sessions.list()
 
     client.request.assert_awaited_with(
         "GET",


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_deploy/issues/337 https://github.com/run-llama/llama_deploy/issues/334

- Use the new `Client`
- Remove generic `JSONResponse`s in favor of specific types
- Consolidated the apiserver portion of the SDK: go lazy and stop pre-filling `items` when creating collections. Will remove the field in a subsequent PR.