### PR TITLE
ci: revamp release job

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -16,73 +16,21 @@ jobs:
     name: Build and publish to PyPI
     if: github.repository == 'run-llama/llama_deploy'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-      - name: Install deps
-        shell: bash
-        run: pip install -e .
+      - uses: actions/checkout@v4
+
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.17
+        uses: JRubics/poetry-publish@v2.0
         with:
+          python_version: ${{ env.PYTHON_VERSION }}
           pypi_token: ${{ secrets.LLAMA_AGENTS_PYPI_TOKEN }}
-          ignore_dev_requirements: "yes"
-      - name: Build Changelog
-        uses: mikepenz/release-changelog-builder-action@v4
-        with:
-          configurationJson: |
-            {
-              "categories": [
-                {
-                    "title": "## Breaking Changes 🛠",
-                    "labels": ["breaking-change", "breaking"]
-                },
-                {
-                    "title": "## New Features 🎉",
-                    "labels": ["enhancement", "feature"]
-                },
-                {
-                    "title": "## Bug Fixes 🐛",
-                    "labels": ["bug", "fix"]
-                },
-                {
-                    "title": "## Documentation 📚",
-                    "labels": ["documentation", "docs", "example", "examples"]
-                }
-              ]
-            }
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          poetry_install_options: "--with dev"
+
       - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Get Asset name
-        run: |
-          export PKG=$(ls dist/ | grep tar)
-          set -- $PKG
-          echo "name=$1" >> $GITHUB_ENV
-      - name: Upload Release Asset (sdist) to GitHub
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/${{ env.name }}
-          asset_name: ${{ env.name }}
-          asset_content_type: application/zip
+          artifacts: "dist/*"
+          generateReleaseNotes: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 coverage.*
 .pytest_cache/
 
+# Build artifacts
+dist/
+
 # Project related
 .tool-versions
 docs/*.lock


### PR DESCRIPTION
- Remove unneeded steps
- Use the Github release notes generator (configured via `release.yml`)
- Use `ncipollo/release-action@v1` to cover multiple tasks with one action