### PR TITLE
fix: make SimpleMessageQueue server cancellable

### DIFF
--- a/e2e_tests/message_queues/message_queue_simple/test_message_queue.py
+++ b/e2e_tests/message_queues/message_queue_simple/test_message_queue.py
@@ -1,0 +1,19 @@
+import asyncio
+
+import pytest
+
+from llama_deploy import SimpleMessageQueue
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_cancel_launch_server():
+    mq = SimpleMessageQueue()
+    t = asyncio.create_task(mq.launch_server())
+
+    # Make sure the queue starts
+    await asyncio.sleep(1)
+
+    # Cancel
+    t.cancel()
+    await t


### PR DESCRIPTION
Several services don't shutdown properly, and while this is not a problem when you tear down the whole process, it's becoming an issue while we start moving towards a more distributed architecture, where services are expected to come and go (think of orchestrators).

This PR makes `SimpleMessageQueue.launch_server()` cancellable, more to come.