### PR TITLE
fix: avoid early exit of RabbitMQ consumer

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,8 +12,6 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    concurrency:
-      group: end-to-end
     strategy:
       # You can use PyPy versions in python-version.
       # For example, pypy-2.7 and pypy-3.8

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: end-to-end
     strategy:
       # You can use PyPy versions in python-version.
       # For example, pypy-2.7 and pypy-3.8

--- a/e2e_tests/message_queues/message_queue_kafka/conftest.py
+++ b/e2e_tests/message_queues/message_queue_kafka/conftest.py
@@ -26,6 +26,7 @@ def kafka_service():
     proc.communicate()
     yield
     subprocess.Popen(["docker", "compose", "-f", f"{compose_file}", "down"])
+    proc.communicate()
 
 
 @pytest.fixture

--- a/e2e_tests/message_queues/message_queue_kafka/conftest.py
+++ b/e2e_tests/message_queues/message_queue_kafka/conftest.py
@@ -97,7 +97,7 @@ def control_planes(kafka_service):
 
     yield
 
-    p1.kill()
-    p2.kill()
-    p3.kill()
-    p4.kill()
+    p1.terminate()
+    p2.terminate()
+    p3.terminate()
+    p4.terminate()

--- a/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
@@ -95,7 +95,7 @@ def control_planes(rabbitmq_service):
 
     yield
 
-    p1.kill()
-    p2.kill()
-    p3.kill()
-    p4.kill()
+    p1.terminate()
+    p2.terminate()
+    p3.terminate()
+    p4.terminate()

--- a/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
@@ -22,6 +22,7 @@ def rabbitmq_service():
     proc.communicate()
     yield
     subprocess.Popen(["docker", "compose", "-f", f"{compose_file}", "down"])
+    proc.communicate()
 
 
 @pytest.fixture

--- a/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
@@ -1,9 +1,16 @@
+import asyncio
+import multiprocessing
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
 
+from llama_deploy import ControlPlaneConfig, WorkflowServiceConfig
+from llama_deploy.deploy import deploy_core, deploy_workflow
 from llama_deploy.message_queues import RabbitMQMessageQueue, RabbitMQMessageQueueConfig
+
+from .workflow import BasicWorkflow
 
 
 @pytest.fixture(scope="package")
@@ -20,3 +27,42 @@ def rabbitmq_service():
 @pytest.fixture
 def mq(rabbitmq_service):
     return RabbitMQMessageQueue(RabbitMQMessageQueueConfig())
+
+
+def run_workflow():
+    asyncio.run(
+        deploy_workflow(
+            BasicWorkflow(timeout=10, name="Workflow one"),
+            WorkflowServiceConfig(
+                host="127.0.0.1",
+                port=8003,
+                service_name="basic",
+            ),
+            ControlPlaneConfig(topic_namespace="core_one", port=8001),
+        )
+    )
+
+
+def run_core():
+    asyncio.run(
+        deploy_core(
+            ControlPlaneConfig(topic_namespace="core_one", port=8001),
+            RabbitMQMessageQueueConfig(),
+        )
+    )
+
+
+@pytest.fixture
+def control_plane(rabbitmq_service):
+    p1 = multiprocessing.Process(target=run_core)
+    p1.start()
+
+    time.sleep(3)
+
+    p2 = multiprocessing.Process(target=run_workflow)
+    p2.start()
+
+    yield
+
+    p1.kill()
+    p2.kill()

--- a/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - "15672:15672"
     healthcheck:
       test: rabbitmq-diagnostics -q ping
-      interval: 30s
-      timeout: 10s
+      interval: 5s
+      timeout: 3s
       retries: 5

--- a/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
@@ -1,12 +1,7 @@
 services:
   rabbitmq:
-    image: rabbitmq:3.13-management
+    image: rabbitmq:3-management-alpine
     hostname: "rabbitmq"
-    environment:
-      RABBITMQ_HOST: "rabbitmq"
-      RABBITMQ_PORT: 5672
-      RABBITMQ_USERNAME: "guest"
-      RABBITMQ_PASSWORD: "guest"
     ports:
       - "5672:5672"
       - "15672:15672"

--- a/e2e_tests/message_queues/message_queue_rabbitmq/test_message_queue.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/test_message_queue.py
@@ -36,10 +36,16 @@ async def test_roundtrip(mq):
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_workflow(control_plane):
-    client = Client(control_plane_url="http://localhost:8001")
+async def test_multiple_control_planes(control_planes):
+    c1 = Client(control_plane_url="http://localhost:8001")
+    c2 = Client(control_plane_url="http://localhost:8002")
 
-    session = await client.core.sessions.create()
-    r1 = await session.run("basic", arg="Hello!")
-    await client.core.sessions.delete(session.id)
-    assert r1 == "Workflow one received Hello!"
+    session = await c1.core.sessions.create()
+    r1 = await session.run("basic", arg="Hello One!")
+    await c1.core.sessions.delete(session.id)
+    assert r1 == "Workflow one received Hello One!"
+
+    session = await c2.core.sessions.create()
+    r2 = await session.run("basic", arg="Hello Two!")
+    await c2.core.sessions.delete(session.id)
+    assert r2 == "Workflow two received Hello Two!"

--- a/e2e_tests/message_queues/message_queue_rabbitmq/test_message_queue.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/test_message_queue.py
@@ -28,6 +28,7 @@ async def test_roundtrip(mq):
     # consume the message
     t = asyncio.create_task(start_consuming_callable())
     await asyncio.sleep(1)
+    t.cancel()
     await t
 
     assert len(received_messages) == 1

--- a/e2e_tests/message_queues/message_queue_rabbitmq/test_message_queue.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/test_message_queue.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from llama_deploy import Client
 from llama_deploy.message_consumers.callable import CallableMessageConsumer
 from llama_deploy.messages import QueueMessage
 
@@ -31,3 +32,14 @@ async def test_roundtrip(mq):
 
     assert len(received_messages) == 1
     assert test_message in received_messages
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_workflow(control_plane):
+    client = Client(control_plane_url="http://localhost:8001")
+
+    session = await client.core.sessions.create()
+    r1 = await session.run("basic", arg="Hello!")
+    await client.core.sessions.delete(session.id)
+    assert r1 == "Workflow one received Hello!"

--- a/e2e_tests/message_queues/message_queue_simple/test_message_queue.py
+++ b/e2e_tests/message_queues/message_queue_simple/test_message_queue.py
@@ -8,7 +8,7 @@ from llama_deploy import SimpleMessageQueue
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_cancel_launch_server():
-    mq = SimpleMessageQueue()
+    mq = SimpleMessageQueue(port=8009)
     t = asyncio.create_task(mq.launch_server())
 
     # Make sure the queue starts

--- a/llama_deploy/message_queues/rabbitmq.py
+++ b/llama_deploy/message_queues/rabbitmq.py
@@ -15,7 +15,7 @@ from llama_deploy.message_consumers.base import (
 from llama_deploy.message_queues.base import AbstractMessageQueue
 from llama_deploy.messages.base import QueueMessage
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from aio_pika import Connection
 
 logger = getLogger(__name__)

--- a/llama_deploy/message_queues/rabbitmq.py
+++ b/llama_deploy/message_queues/rabbitmq.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -33,12 +33,12 @@ class RabbitMQMessageQueueConfig(BaseSettings):
     type: Literal["rabbitmq"] = Field(default="rabbitmq", exclude=True)
     url: str = DEFAULT_URL
     exchange_name: str = DEFAULT_EXCHANGE_NAME
-    username: Optional[str] = None
-    password: Optional[str] = None
-    host: Optional[str] = None
-    port: Optional[int] = None
-    vhost: Optional[str] = None
-    secure: Optional[bool] = None
+    username: str | None = None
+    password: str | None = None
+    host: str | None = None
+    port: int | None = None
+    vhost: str | None = None
+    secure: bool | None = None
 
     def model_post_init(self, __context: Any) -> None:
         if self.username and self.password and self.host:
@@ -117,7 +117,7 @@ class RabbitMQMessageQueue(AbstractMessageQueue):
         password: str,
         host: str,
         vhost: str = "",
-        port: Optional[int] = None,
+        port: int | None = None,
         secure: bool = False,
         exchange_name: str = DEFAULT_EXCHANGE_NAME,
     ) -> "RabbitMQMessageQueue":
@@ -127,7 +127,7 @@ class RabbitMQMessageQueue(AbstractMessageQueue):
             username (str): username for the amqp authority
             password (str): password for the amqp authority
             host (str): host for rabbitmq server
-            port (Optional[int], optional): port for rabbitmq server. Defaults to None.
+            port (int | None, optional): port for rabbitmq server. Defaults to None.
             secure (bool, optional): Whether or not to use SSL. Defaults to False.
             exchange_name (str, optional): The exchange name. Defaults to DEFAULT_EXCHANGE_NAME.
 
@@ -253,7 +253,7 @@ class RabbitMQMessageQueue(AbstractMessageQueue):
         pass
 
     async def cleanup_local(
-        self, message_types: List[str], *args: Any, **kwargs: Dict[str, Any]
+        self, message_types: list[str], *args: Any, **kwargs: dict[str, Any]
     ) -> None:
         """Perform any clean up of queues and exchanges."""
         connection = await self.new_connection()

--- a/llama_deploy/message_queues/rabbitmq.py
+++ b/llama_deploy/message_queues/rabbitmq.py
@@ -217,6 +217,7 @@ class RabbitMQMessageQueue(AbstractMessageQueue):
                 queue = cast(Queue, await channel.declare_queue(name=topic))
                 await queue.bind(exchange)
                 await queue.consume(on_message)
+                await asyncio.Future()
 
         return start_consuming_callable
 

--- a/tests/message_queues/test_rabbitmq.py
+++ b/tests/message_queues/test_rabbitmq.py
@@ -53,7 +53,7 @@ async def test_register_consumer() -> None:
         await asyncio.sleep(0)
         task.cancel()
         await task
-        assert connection.assert_awaited_with("amqp://guest:guest@localhost/")
+        connection.assert_awaited()
 
 
 def test_init() -> None:

--- a/tests/message_queues/test_rabbitmq.py
+++ b/tests/message_queues/test_rabbitmq.py
@@ -93,4 +93,4 @@ async def test_publish(mock_connect: MagicMock) -> None:
     assert args[0].body == aio_pika_message.body
     assert args[0].body_size == aio_pika_message.body_size
     assert args[0].delivery_mode == aio_pika_message.delivery_mode
-    assert kwargs["routing_key"] == queue_message.type
+    assert kwargs["routing_key"] == "test"


### PR DESCRIPTION
Fixes #393 #362

Problem found: the message consumer task was exiting after the first message received. The bug didn't surface probably because most of our tests are happy with a roundtrip of one message only

In this PR:
- Added `await asyncio.Future()` to keep the message consumer around. I don't particularly like this fix but it seems to be the idiomatic way to do it with Rabbit from what I found online. FWIW Claude suggested the same fix when prompted so there must be some statistical corroboration behind :)
- Made the message queue use the `topic` as dictated from the control plane, solving #362. Also added proper e2e tests around this
- Updated type annotations