### PR TITLE
ci: try a different strategy for rabbit health check

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -13,8 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      # You can use PyPy versions in python-version.
-      # For example, pypy-2.7 and pypy-3.8
+      # Let the matrix finish to see if the failure was transient
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:

--- a/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
@@ -13,7 +13,7 @@ from llama_deploy.message_queues import RabbitMQMessageQueue, RabbitMQMessageQue
 from .workflow import BasicWorkflow
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="session")
 def rabbitmq_service():
     compose_file = Path(__file__).resolve().parent / "docker-compose.yml"
     proc = subprocess.Popen(

--- a/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
@@ -20,8 +20,6 @@ def rabbitmq_service():
         ["docker", "compose", "-f", f"{compose_file}", "up", "-d", "--wait"]
     )
     proc.communicate()
-    # Give some time to further boot
-    time.sleep(5)
     yield
     subprocess.Popen(["docker", "compose", "-f", f"{compose_file}", "down"])
     proc.communicate()

--- a/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/conftest.py
@@ -20,6 +20,8 @@ def rabbitmq_service():
         ["docker", "compose", "-f", f"{compose_file}", "up", "-d", "--wait"]
     )
     proc.communicate()
+    # Give some time to further boot
+    time.sleep(5)
     yield
     subprocess.Popen(["docker", "compose", "-f", f"{compose_file}", "down"])
     proc.communicate()

--- a/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "15672:15672"
     healthcheck:
       test:
-        - sh
+        - CMD-SHELL
         - -c
         - |
           rabbitmq-diagnostics -q check_running

--- a/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "5672:5672"
       - "15672:15672"
     healthcheck:
-      test: rabbitmq-diagnostics -q check_running
+      test: rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_port_connectivity
       interval: 5s
       timeout: 3s
       retries: 5

--- a/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
@@ -6,7 +6,12 @@ services:
       - "5672:5672"
       - "15672:15672"
     healthcheck:
-      test: rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_port_connectivity
+      test:
+        - sh
+        - -c
+        - |
+          rabbitmq-diagnostics -q check_running
+          rabbitmq-diagnostics -q check_port_connectivity
       interval: 5s
       timeout: 3s
       retries: 5

--- a/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "5672:5672"
       - "15672:15672"
     healthcheck:
-      test: rabbitmq-diagnostics -q ping
+      test: rabbitmq-diagnostics -q status
       interval: 5s
       timeout: 3s
       retries: 5

--- a/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
+++ b/e2e_tests/message_queues/message_queue_rabbitmq/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "5672:5672"
       - "15672:15672"
     healthcheck:
-      test: rabbitmq-diagnostics -q status
+      test: rabbitmq-diagnostics -q check_running
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
I suspect the healthcheck never really worked because the `CMD-SHELL` was missing from the test command. This would explain why with an interval of 30s it seemed to work (30 seconds are more than enough to boot rabbit and a falsely positive healthcheck would be fine at that point).