### PR TITLE
fix: apiserver doesn't set session id when creating a task

### DIFF
--- a/e2e_tests/apiserver/test_streaming.py
+++ b/e2e_tests/apiserver/test_streaming.py
@@ -14,7 +14,7 @@ async def test_stream(apiserver, client):
         deployment = await client.apiserver.deployments.create(f)
         await asyncio.sleep(5)
 
-    tasks = await deployment.tasks()
+    tasks = deployment.tasks
     task = await tasks.create(TaskDefinition(input='{"a": "b"}'))
     read_events = []
     async for ev in task.events():

--- a/e2e_tests/basic_streaming/test_run_client.py
+++ b/e2e_tests/basic_streaming/test_run_client.py
@@ -17,16 +17,11 @@ def test_run_client(services):
     # kick off run
     task_id = session.run_nowait("streaming_workflow", arg1="hello_world")
 
-    num_events = 0
+    progress_received = []
     for event in session.get_task_result_stream(task_id):
         if "progress" in event:
-            num_events += 1
-            if num_events == 1:
-                assert event["progress"] == 0.3
-            elif num_events == 2:
-                assert event["progress"] == 0.6
-            elif num_events == 3:
-                assert event["progress"] == 0.9
+            progress_received.append(event["progress"])
+    assert progress_received == [0.3, 0.6, 0.9]
 
     # get final result
     final_result = session.get_task_result(task_id)
@@ -47,16 +42,11 @@ async def test_run_client_async(services):
     # kick off run
     task_id = await session.run_nowait("streaming_workflow", arg1="hello_world")
 
-    num_events = 0
+    progress_received = []
     async for event in session.get_task_result_stream(task_id):
         if "progress" in event:
-            num_events += 1
-            if num_events == 1:
-                assert event["progress"] == 0.3
-            elif num_events == 2:
-                assert event["progress"] == 0.6
-            elif num_events == 3:
-                assert event["progress"] == 0.9
+            progress_received.append(event["progress"])
+    assert progress_received == [0.3, 0.6, 0.9]
 
     final_result = await session.get_task_result(task_id)
     assert final_result.result == "hello_world_result_result_result"  # type: ignore

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -94,6 +94,7 @@ async def create_deployment_task_nowait(
         session = await deployment.client.core.sessions.get(session_id)
     else:
         session = await deployment.client.core.sessions.create()
+        session_id = session.id
 
     task_definition.session_id = session_id
     task_definition.task_id = await session.run_nowait(


### PR DESCRIPTION
Probably a leftover of the migration to the new Client, not sure why e2e didn't catch it earlier