### PR TITLE
[feat] Add send event endpoints to api server

### DIFF
--- a/e2e_tests/apiserver/deployments/deployment_hitl.yml
+++ b/e2e_tests/apiserver/deployments/deployment_hitl.yml
@@ -1,0 +1,14 @@
+name: HumanInTheLoop
+
+control-plane:
+  port: 8000
+
+default-service: hitl_workflow
+
+services:
+  hitl_workflow:
+    name: HITL Workflow
+    source:
+      type: local
+      name: ./e2e_tests/apiserver/deployments/src
+    path: workflow_hitl:workflow

--- a/e2e_tests/apiserver/deployments/src/workflow_hitl.py
+++ b/e2e_tests/apiserver/deployments/src/workflow_hitl.py
@@ -1,0 +1,23 @@
+from llama_index.core.workflow import (
+    StartEvent,
+    StopEvent,
+    Workflow,
+    step,
+)
+from llama_index.core.workflow.events import (
+    HumanResponseEvent,
+    InputRequiredEvent,
+)
+
+
+class HumanInTheLoopWorkflow(Workflow):
+    @step
+    async def step1(self, ev: StartEvent) -> InputRequiredEvent:
+        return InputRequiredEvent(prefix="Enter a number: ")
+
+    @step
+    async def step2(self, ev: HumanResponseEvent) -> StopEvent:
+        return StopEvent(result=ev.response)
+
+
+workflow = HumanInTheLoopWorkflow()

--- a/e2e_tests/apiserver/test_hitl.py
+++ b/e2e_tests/apiserver/test_hitl.py
@@ -1,0 +1,30 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from llama_deploy.types import TaskDefinition
+
+from llama_index.core.workflow.events import HumanResponseEvent
+
+
+@pytest.mark.asyncio
+async def test_hitl(apiserver, client):
+    here = Path(__file__).parent
+
+    with open(here / "deployments" / "deployment_hitl.yml") as f:
+        deployment = await client.apiserver.deployments.create(f)
+        await asyncio.sleep(5)
+
+    tasks = deployment.tasks
+    task = await tasks.create(TaskDefinition(input="{}"))
+    r = await task.send_human_response(response="42", service_name="hitl_workflow")
+    ev = HumanResponseEvent.model_validate(r.model_dump())
+
+    # wait for workflow to finish
+    await asyncio.sleep(0.5)
+
+    result = await task.results()
+
+    assert ev.response == "42"
+    assert result.result == "42", "The human's response is not consistent."

--- a/e2e_tests/apiserver/test_hitl.py
+++ b/e2e_tests/apiserver/test_hitl.py
@@ -3,9 +3,10 @@ from pathlib import Path
 
 import pytest
 
-from llama_deploy.types import TaskDefinition
+from llama_deploy.types import TaskDefinition, EventDefinition
 
 from llama_index.core.workflow.events import HumanResponseEvent
+from llama_index.core.workflow.context_serializers import JsonSerializer
 
 
 @pytest.mark.asyncio
@@ -18,13 +19,15 @@ async def test_hitl(apiserver, client):
 
     tasks = deployment.tasks
     task = await tasks.create(TaskDefinition(input="{}"))
-    r = await task.send_human_response(response="42", service_name="hitl_workflow")
-    ev = HumanResponseEvent.model_validate(r.model_dump())
+    ev = HumanResponseEvent(response="42")
+    r = await task.send_event(ev=ev, service_name="hitl_workflow")
+    ev_def = EventDefinition.model_validate(r.model_dump())
 
     # wait for workflow to finish
     await asyncio.sleep(0.5)
 
     result = await task.results()
 
-    assert ev.response == "42"
+    assert ev_def.agent_id == "hitl_workflow"
+    assert ev_def.event_obj_str == JsonSerializer().serialize(ev)
     assert result.result == "42", "The human's response is not consistent."

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -10,10 +10,10 @@ from llama_deploy.types import (
     DeploymentDefinition,
     SessionDefinition,
     TaskDefinition,
+    EventDefinition,
 )
 from llama_deploy.types.core import TaskResult
 
-from llama_index.core.workflow.events import HumanResponseEvent
 
 deployments_router = APIRouter(
     prefix="/deployments",
@@ -110,14 +110,13 @@ async def create_deployment_task_nowait(
     return task_definition
 
 
-@deployments_router.post("/{deployment_name}/tasks/{task_id}/human_response_event")
-async def send_human_response_event(
+@deployments_router.post("/{deployment_name}/tasks/{task_id}/events")
+async def send_event(
     deployment_name: str,
     task_id: str,
     session_id: str,
-    service_name: str,
-    event: HumanResponseEvent,
-) -> HumanResponseEvent:
+    event_def: EventDefinition,
+) -> EventDefinition:
     """Send a human response event to a service for a specific task and session."""
     deployment = manager.get_deployment(deployment_name)
     if deployment is None:
@@ -125,9 +124,9 @@ async def send_human_response_event(
 
     session = await deployment.client.core.sessions.get(session_id)
 
-    await session.send_event(service_name=service_name, task_id=task_id, ev=event)
+    await session.send_event(task_id=task_id, event_def=event_def)
 
-    return event
+    return event_def
 
 
 @deployments_router.get("/{deployment_name}/tasks/{task_id}/events")

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -124,7 +124,7 @@ async def send_event(
 
     session = await deployment.client.core.sessions.get(session_id)
 
-    await session.send_event(task_id=task_id, event_def=event_def)
+    await session.send_event_def(task_id=task_id, ev_def=event_def)
 
     return event_def
 

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -6,7 +6,12 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from llama_deploy.apiserver.config_parser import Config
 from llama_deploy.apiserver.server import manager
-from llama_deploy.types import DeploymentDefinition, SessionDefinition, TaskDefinition
+from llama_deploy.types import (
+    DeploymentDefinition,
+    SessionDefinition,
+    TaskDefinition,
+    EventDefinition,
+)
 from llama_deploy.types.core import TaskResult
 
 deployments_router = APIRouter(
@@ -102,6 +107,12 @@ async def create_deployment_task_nowait(
     )
 
     return task_definition
+
+
+@deployments_router.post("/{deployment_name}/tasks/{task_id}/events")
+async def send_event(
+    deployment_name: str, session_id: str, task_id: str, event_def: EventDefinition
+) -> None: ...
 
 
 @deployments_router.get("/{deployment_name}/tasks/{task_id}/events")

--- a/llama_deploy/client/models/apiserver.py
+++ b/llama_deploy/client/models/apiserver.py
@@ -91,7 +91,7 @@ class Task(Model):
 
     async def send_event(self, ev: Event, service_name: str) -> EventDefinition:
         """Sends a human response event."""
-        url = f"{self.client.api_server_url}/deployments/{self.deployment_id}/tasks/{self.id}/send_event"
+        url = f"{self.client.api_server_url}/deployments/{self.deployment_id}/tasks/{self.id}/events"
 
         serializer = JsonSerializer()
         event_def = EventDefinition(
@@ -102,7 +102,7 @@ class Task(Model):
             "POST",
             url,
             verify=not self.client.disable_ssl,
-            params={"session_id": self.session_id, "service_name": service_name},
+            params={"session_id": self.session_id},
             json=event_def.model_dump(),
             timeout=self.client.timeout,
         )

--- a/llama_deploy/client/models/apiserver.py
+++ b/llama_deploy/client/models/apiserver.py
@@ -94,6 +94,7 @@ class Task(Model):
             url,
             verify=not self.client.disable_ssl,
             params={"session_id": self.session_id, "service_name": service_name},
+            json={"response": response},
             timeout=self.client.timeout,
         )
         return HumanResponseEvent.model_validate_json(r.json())

--- a/llama_deploy/client/models/apiserver.py
+++ b/llama_deploy/client/models/apiserver.py
@@ -81,7 +81,7 @@ class Task(Model):
             params={"session_id": self.session_id},
             timeout=self.client.timeout,
         )
-        return TaskResult.model_validate_json(r.json())
+        return TaskResult.model_validate(r.json())
 
     async def send_human_response(
         self, response: str, service_name: str
@@ -97,7 +97,7 @@ class Task(Model):
             json={"response": response},
             timeout=self.client.timeout,
         )
-        return HumanResponseEvent.model_validate_json(r.json())
+        return HumanResponseEvent.model_validate(r.json())
 
     async def events(self) -> AsyncGenerator[dict[str, Any], None]:  # pragma: no cover
         """Returns a generator object to consume the events streamed from a service."""

--- a/llama_deploy/client/models/core.py
+++ b/llama_deploy/client/models/core.py
@@ -90,11 +90,13 @@ class Session(Model):
         response = await self.client.request("GET", url)
         return [TaskDefinition(**task) for task in response.json()]
 
-    async def send_event(self, task_id: str, event_def: EventDefinition) -> None:
+    async def send_event(
+        self, service_name: str, task_id: str, event_def: EventDefinition
+    ) -> None:
         """Send event to a Workflow service.
 
         Args:
-            event_def (EventDefinition): Contains serialized str of Event and target service name.
+            event (Event): The event to be submitted to the workflow.
 
         Returns:
             None

--- a/llama_deploy/client/models/core.py
+++ b/llama_deploy/client/models/core.py
@@ -4,8 +4,6 @@ import time
 from typing import Any, AsyncGenerator
 
 import httpx
-from llama_index.core.workflow import Event
-from llama_index.core.workflow.context_serializers import JsonSerializer
 
 from llama_deploy.types.core import (
     EventDefinition,
@@ -92,20 +90,15 @@ class Session(Model):
         response = await self.client.request("GET", url)
         return [TaskDefinition(**task) for task in response.json()]
 
-    async def send_event(self, service_name: str, task_id: str, ev: Event) -> None:
+    async def send_event(self, task_id: str, event_def: EventDefinition) -> None:
         """Send event to a Workflow service.
 
         Args:
-            event (Event): The event to be submitted to the workflow.
+            event_def (EventDefinition): Contains serialized str of Event and target service name.
 
         Returns:
             None
         """
-        serializer = JsonSerializer()
-        event_def = EventDefinition(
-            event_obj_str=serializer.serialize(ev), agent_id=service_name
-        )
-
         url = f"{self.client.control_plane_url}/sessions/{self.id}/tasks/{task_id}/send_event"
         await self.client.request("POST", url, json=event_def.model_dump())
 

--- a/llama_deploy/client/models/core.py
+++ b/llama_deploy/client/models/core.py
@@ -109,6 +109,18 @@ class Session(Model):
         url = f"{self.client.control_plane_url}/sessions/{self.id}/tasks/{task_id}/send_event"
         await self.client.request("POST", url, json=event_def.model_dump())
 
+    async def send_event_def(self, task_id: str, ev_def: EventDefinition) -> None:
+        """Send event to a Workflow service.
+
+        Args:
+            event (Event): The event to be submitted to the workflow.
+
+        Returns:
+            None
+        """
+        url = f"{self.client.control_plane_url}/sessions/{self.id}/tasks/{task_id}/send_event"
+        await self.client.request("POST", url, json=ev_def.model_dump())
+
     async def get_task_result_stream(
         self, task_id: str
     ) -> AsyncGenerator[dict[str, Any], None]:

--- a/llama_deploy/client/models/core.py
+++ b/llama_deploy/client/models/core.py
@@ -4,6 +4,8 @@ import time
 from typing import Any, AsyncGenerator
 
 import httpx
+from llama_index.core.workflow import Event
+from llama_index.core.workflow.context_serializers import JsonSerializer
 
 from llama_deploy.types.core import (
     EventDefinition,
@@ -90,9 +92,7 @@ class Session(Model):
         response = await self.client.request("GET", url)
         return [TaskDefinition(**task) for task in response.json()]
 
-    async def send_event(
-        self, service_name: str, task_id: str, event_def: EventDefinition
-    ) -> None:
+    async def send_event(self, service_name: str, task_id: str, ev: Event) -> None:
         """Send event to a Workflow service.
 
         Args:
@@ -101,6 +101,11 @@ class Session(Model):
         Returns:
             None
         """
+        serializer = JsonSerializer()
+        event_def = EventDefinition(
+            event_obj_str=serializer.serialize(ev), agent_id=service_name
+        )
+
         url = f"{self.client.control_plane_url}/sessions/{self.id}/tasks/{task_id}/send_event"
         await self.client.request("POST", url, json=event_def.model_dump())
 

--- a/tests/client/models/test_apiserver.py
+++ b/tests/client/models/test_apiserver.py
@@ -90,7 +90,7 @@ async def test_session_collection_list(client: Any) -> None:
 @pytest.mark.asyncio
 async def test_task_results(client: Any) -> None:
     res = TaskResult(task_id="a_result", history=[], result="some_text", data={})
-    client.request.return_value = mock.MagicMock(json=lambda: res.model_dump_json())
+    client.request.return_value = mock.MagicMock(json=lambda: res.model_dump())
 
     t = Task(
         client=client,


### PR DESCRIPTION
This PR adds a new endpoint in api server allowing users to post a new `Event` that gets sent to a running workflow of a specified deployment.

I've also added the `send_event()` method to the `Task` apiserver/model class.