### PR TITLE
fix: use the image tag in the docker run examples

### DIFF
--- a/docs/docs/module_guides/llama_deploy/10_getting_started.md
+++ b/docs/docs/module_guides/llama_deploy/10_getting_started.md
@@ -98,7 +98,7 @@ if you have Docker installed, you can replace running the API server locally wit
 with:
 
 ```
-$ docker run -p 4501:4501 -v .:/opt/quickstart -w /opt/quickstart llamaindex/llama-deploy
+$ docker run -p 4501:4501 -v .:/opt/quickstart -w /opt/quickstart llamaindex/llama-deploy:main
 INFO:     Started server process [1]
 INFO:     Waiting for application startup.
 INFO:     Application startup complete.
@@ -107,3 +107,8 @@ INFO:     Uvicorn running on http://0.0.0.0:4501 (Press CTRL+C to quit)
 
 The API server will be available at `http://localhost:4501` on your host, so `llamactl` will work the same as if you
 run `python -m llama_deploy.apiserver`.
+
+> [!NOTE]
+> The `llamaindex/llama-deploy:main` Docker image is continuously built from the latest commit in the `main`
+> branch of the git repository. While this ensures you get the most recent version of the project, the
+> image might contain unreleased features that are not fully stable, use with caution!

--- a/examples/quick_start/README.md
+++ b/examples/quick_start/README.md
@@ -89,7 +89,7 @@ if you have Docker installed, you can replace running the API server locally wit
 with:
 
 ```
-$ docker run -p 4501:4501 -v .:/opt/quickstart -w /opt/quickstart llamaindex/llama-deploy
+$ docker run -p 4501:4501 -v .:/opt/quickstart -w /opt/quickstart llamaindex/llama-deploy:main
 INFO:     Started server process [1]
 INFO:     Waiting for application startup.
 INFO:     Application startup complete.


### PR DESCRIPTION
Explicitly add the `main` tag to the code examples showing how to run the Docker container. The `main` image is usually fairly stable so it should be ok to use in the examples.

Fixes #415 
