### PR TITLE
feat: Reload a running deployment.

### DIFF
--- a/e2e_tests/apiserver/deployments/deployment1.yml
+++ b/e2e_tests/apiserver/deployments/deployment1.yml
@@ -11,5 +11,5 @@ services:
     host: localhost
     source:
       type: git
-      name: https://github.com/run-llama/llama_deploy.git
-    path: tests/apiserver/data/workflow:my_workflow
+      name: https://github.com/run-llama/llama_deploy.git@massi/322
+    path: e2e_tests/apiserver/deployments/src:my_workflow

--- a/e2e_tests/apiserver/deployments/deployment2.yml
+++ b/e2e_tests/apiserver/deployments/deployment2.yml
@@ -11,5 +11,5 @@ services:
     host: localhost
     source:
       type: git
-      name: https://github.com/run-llama/llama_deploy.git
-    path: tests/apiserver/data/workflow:my_workflow
+      name: https://github.com/run-llama/llama_deploy.git@massi/322
+    path: e2e_tests/apiserver/deployments/src:my_workflow

--- a/e2e_tests/apiserver/deployments/deployment_reload1.yml
+++ b/e2e_tests/apiserver/deployments/deployment_reload1.yml
@@ -1,0 +1,15 @@
+name: ReloadMe
+
+control-plane: {}
+
+default-service: test-workflow
+
+services:
+  test-workflow:
+    name: Test Workflow
+    port: 8002
+    host: localhost
+    source:
+      type: git
+      name: https://github.com/run-llama/llama_deploy.git@massi/322
+    path: e2e_tests/apiserver/deployments/src:echo_workflow_en

--- a/e2e_tests/apiserver/deployments/deployment_reload2.yml
+++ b/e2e_tests/apiserver/deployments/deployment_reload2.yml
@@ -1,0 +1,15 @@
+name: ReloadMe
+
+control-plane: {}
+
+default-service: test-workflow
+
+services:
+  test-workflow:
+    name: Test Workflow
+    port: 8002
+    host: localhost
+    source:
+      type: git
+      name: https://github.com/run-llama/llama_deploy.git@massi/322
+    path: e2e_tests/apiserver/deployments/src:echo_workflow_it

--- a/e2e_tests/apiserver/deployments/src/__init__.py
+++ b/e2e_tests/apiserver/deployments/src/__init__.py
@@ -1,0 +1,3 @@
+from .workflow import EchoWorkflow
+
+my_workflow = EchoWorkflow()

--- a/e2e_tests/apiserver/deployments/src/__init__.py
+++ b/e2e_tests/apiserver/deployments/src/__init__.py
@@ -1,3 +1,6 @@
 from .workflow import EchoWorkflow
+from .workflow_reload import EchoWithPrompt
 
 my_workflow = EchoWorkflow()
+echo_workflow_en = EchoWithPrompt(prompt_msg="I have received:")
+echo_workflow_it = EchoWithPrompt(prompt_msg="Ho ricevuto:")

--- a/e2e_tests/apiserver/deployments/src/workflow_reload.py
+++ b/e2e_tests/apiserver/deployments/src/workflow_reload.py
@@ -1,0 +1,11 @@
+from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
+
+
+class EchoWithPrompt(Workflow):
+    def __init__(self, prompt_msg):
+        super().__init__()
+        self._prompt_msg = prompt_msg
+
+    @step
+    def do_something(self, ctx: Context, ev: StartEvent) -> StopEvent:
+        return StopEvent(result=f"{self._prompt_msg}{ev.data}")

--- a/e2e_tests/apiserver/test_reload.py
+++ b/e2e_tests/apiserver/test_reload.py
@@ -1,0 +1,26 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from llama_deploy.types import TaskDefinition
+
+
+@pytest.mark.asyncio
+async def test_reload(apiserver, client):
+    here = Path(__file__).parent
+    with open(here / "deployments" / "deployment_reload1.yml") as f:
+        deployment = await client.apiserver.deployments.create(f)
+        await asyncio.sleep(3)
+
+    tasks = deployment.tasks
+    res = await tasks.run(TaskDefinition(input='{"data": "bar"}'))
+    assert res == "I have received:bar"
+
+    with open(here / "deployments" / "deployment_reload2.yml") as f:
+        deployment = await client.apiserver.deployments.create(f, reload=True)
+        await asyncio.sleep(3)
+
+    tasks = deployment.tasks
+    res = await tasks.run(TaskDefinition(input='{"data": "bar"}'))
+    assert res == "Ho ricevuto:bar"

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -124,6 +124,7 @@ class Deployment:
         self._running = False
 
     async def reload(self, config: Config) -> None:
+        """Reload this deployment by restarting its services."""
         self._workflow_services = self._load_services(config)
         self._default_service = config.default_service
 

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -193,6 +193,12 @@ class Deployment:
             destination = (self._path / service_id).resolve()
 
             if destination.exists():
+                # FIXME: this could be managed at the source manager level, so that
+                # each implementation can decide what to do with existing data. For
+                # example, the git source manager might decide to perform a git pull
+                # instead of a brand new git clone. Leaving these optimnizations for
+                # later, for the time being having an empty data folder works smoothly
+                # for any source manager currently supported.
                 rmtree(str(destination))
 
             source_manager = SOURCE_MANAGERS[source.type]

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -8,12 +8,11 @@ from llama_deploy.apiserver.config_parser import Config
 from llama_deploy.apiserver.server import manager
 from llama_deploy.types import (
     DeploymentDefinition,
+    EventDefinition,
     SessionDefinition,
     TaskDefinition,
-    EventDefinition,
 )
 from llama_deploy.types.core import TaskResult
-
 
 deployments_router = APIRouter(
     prefix="/deployments",
@@ -37,11 +36,11 @@ async def read_deployment(deployment_name: str) -> DeploymentDefinition:
 
 @deployments_router.post("/create")
 async def create_deployment(
-    config_file: UploadFile = File(...),
+    config_file: UploadFile = File(...), reload: bool = False
 ) -> DeploymentDefinition:
     """Creates a new deployment by uploading a configuration file."""
     config = Config.from_yaml_bytes(await config_file.read())
-    manager.deploy(config)
+    manager.deploy(config, reload)
 
     return DeploymentDefinition(name=config.name)
 

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -40,7 +40,7 @@ async def create_deployment(
 ) -> DeploymentDefinition:
     """Creates a new deployment by uploading a configuration file."""
     config = Config.from_yaml_bytes(await config_file.read())
-    manager.deploy(config, reload)
+    await manager.deploy(config, reload)
 
     return DeploymentDefinition(name=config.name)
 

--- a/llama_deploy/cli/deploy.py
+++ b/llama_deploy/cli/deploy.py
@@ -7,13 +7,16 @@ from llama_deploy import Client
 
 @click.command()
 @click.pass_obj  # global_config
+@click.option("--reload", is_flag=True)
 @click.argument("deployment_config_file", type=click.File("rb"))
-def deploy(global_config: tuple, deployment_config_file: IO) -> None:
+def deploy(global_config: tuple, reload: bool, deployment_config_file: IO) -> None:
     server_url, disable_ssl, timeout = global_config
     client = Client(api_server_url=server_url, disable_ssl=disable_ssl, timeout=timeout)
 
     try:
-        deployment = client.sync.apiserver.deployments.create(deployment_config_file)
+        deployment = client.sync.apiserver.deployments.create(
+            deployment_config_file, reload
+        )
     except Exception as e:
         raise click.ClickException(str(e))
 

--- a/llama_deploy/client/models/apiserver.py
+++ b/llama_deploy/client/models/apiserver.py
@@ -3,9 +3,8 @@ import json
 from typing import Any, AsyncGenerator, TextIO
 
 import httpx
-
-from llama_index.core.workflow.events import Event
 from llama_index.core.workflow.context_serializers import JsonSerializer
+from llama_index.core.workflow.events import Event
 
 from llama_deploy.types.apiserver import Status, StatusEnum
 from llama_deploy.types.core import (
@@ -227,8 +226,11 @@ class Deployment(Model):
 class DeploymentCollection(Collection):
     """A model representing a collection of deployments currently active."""
 
-    async def create(self, config: TextIO) -> Deployment:
+    async def create(self, config: TextIO, reload: bool = False) -> Deployment:
         """Creates a new deployment from a deployment file.
+
+        If `reload` is true, an existing deployment will be reloaded, otherwise
+        an error will be raised.
 
         Example:
             ```
@@ -243,6 +245,7 @@ class DeploymentCollection(Collection):
             "POST",
             create_url,
             files=files,
+            params={"reload": reload},
             verify=not self.client.disable_ssl,
             timeout=self.client.timeout,
         )

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -37,6 +37,7 @@ def test_create_deployment(http_client: TestClient, data_path: Path) -> None:
     with mock.patch(
         "llama_deploy.apiserver.routers.deployments.manager"
     ) as mocked_manager:
+        mocked_manager.deploy = mock.AsyncMock()
         config_file = data_path / "git_service.yaml"
 
         with open(config_file, "rb") as f:
@@ -47,7 +48,7 @@ def test_create_deployment(http_client: TestClient, data_path: Path) -> None:
             )
 
         assert response.status_code == 200
-        mocked_manager.deploy.assert_called_with(actual_config, False)
+        mocked_manager.deploy.assert_awaited_with(actual_config, False)
 
 
 def test_create_deployment_task_not_found(

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -4,12 +4,12 @@ from unittest import mock
 
 import pytest
 from fastapi.testclient import TestClient
-from llama_index.core.workflow.events import Event, HumanResponseEvent
 from llama_index.core.workflow.context_serializers import JsonSerializer
+from llama_index.core.workflow.events import Event, HumanResponseEvent
 
 from llama_deploy.apiserver import Config
 from llama_deploy.types import TaskResult
-from llama_deploy.types.core import TaskDefinition, EventDefinition
+from llama_deploy.types.core import EventDefinition, TaskDefinition
 
 
 def test_read_deployments(http_client: TestClient) -> None:
@@ -47,7 +47,7 @@ def test_create_deployment(http_client: TestClient, data_path: Path) -> None:
             )
 
         assert response.status_code == 200
-        mocked_manager.deploy.assert_called_with(actual_config)
+        mocked_manager.deploy.assert_called_with(actual_config, False)
 
 
 def test_create_deployment_task_not_found(

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -178,17 +178,19 @@ def test_manager_ctor() -> None:
     assert m.get_deployment("foo") is None
 
 
-def test_manager_deploy_duplicate(data_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_manager_deploy_duplicate(data_path: Path) -> None:
     config = Config.from_yaml(data_path / "git_service.yaml")
 
     m = Manager()
     m._deployments["TestDeployment"] = mock.MagicMock()
 
     with pytest.raises(ValueError, match="Deployment already exists: TestDeployment"):
-        m.deploy(config)
+        await m.deploy(config)
 
 
-def test_manager_deploy_maximum_reached(data_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_manager_deploy_maximum_reached(data_path: Path) -> None:
     config = Config.from_yaml(data_path / "git_service.yaml")
 
     m = Manager(max_deployments=1)
@@ -198,16 +200,17 @@ def test_manager_deploy_maximum_reached(data_path: Path) -> None:
         ValueError,
         match="Reached the maximum number of deployments, cannot schedule more",
     ):
-        m.deploy(config)
+        await m.deploy(config)
 
 
-def test_manager_deploy(data_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_manager_deploy(data_path: Path) -> None:
     config = Config.from_yaml(data_path / "git_service.yaml")
     with mock.patch(
         "llama_deploy.apiserver.deployment.Deployment"
     ) as mocked_deployment:
         m = Manager()
-        m.deploy(config)
+        await m.deploy(config)
         mocked_deployment.assert_called_once()
         assert m.deployment_names == ["TestDeployment"]
         assert m.get_deployment("TestDeployment") is not None

--- a/tests/client/models/test_apiserver.py
+++ b/tests/client/models/test_apiserver.py
@@ -218,6 +218,7 @@ async def test_task_deployment_collection_create(client: Any) -> None:
         "POST",
         "http://localhost:4501/deployments/create",
         files={"config_file": "some config"},
+        params={"reload": False},
         verify=True,
         timeout=120.0,
     )


### PR DESCRIPTION
Fixes #322 

Reload a running deployment by restarting its services. The message queue and the control plane won't be restarted, the thread running the dedicated ioloop for this deployment will stay active.