### PR TITLE
refact: remove BaseMessageQueue in favor of AbstractMessageQueue

### DIFF
--- a/docs/docs/api_reference/llama_deploy/message_queues/index.md
+++ b/docs/docs/api_reference/llama_deploy/message_queues/index.md
@@ -3,4 +3,4 @@
 ::: llama_deploy.message_queues.base
     options:
         members:
-        - BaseMessageQueue
+        - AbstractMessageQueue

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -20,8 +20,8 @@ from llama_deploy import (
     WorkflowServiceConfig,
 )
 from llama_deploy.message_queues import (
+    AbstractMessageQueue,
     AWSMessageQueue,
-    BaseMessageQueue,
     KafkaMessageQueue,
     RabbitMQMessageQueue,
     RedisMessageQueue,
@@ -276,25 +276,25 @@ class Deployment:
 
     def _load_message_queue_client(
         self, cfg: MessageQueueConfig | None
-    ) -> BaseMessageQueue:
+    ) -> AbstractMessageQueue:
         # Use the SimpleMessageQueue as the default
         if cfg is None:
             # we use model_validate instead of __init__ to avoid static checkers complaining over field aliases
             cfg = SimpleMessageQueueConfig()
 
         if cfg.type == "aws":
-            return AWSMessageQueue(cfg)  # type: ignore
+            return AWSMessageQueue(cfg)
         elif cfg.type == "kafka":
-            return KafkaMessageQueue(cfg)  # type: ignore
+            return KafkaMessageQueue(cfg)
         elif cfg.type == "rabbitmq":
-            return RabbitMQMessageQueue(cfg)  # type: ignore
+            return RabbitMQMessageQueue(cfg)
         elif cfg.type == "redis":
-            return RedisMessageQueue(cfg)  # type: ignore
+            return RedisMessageQueue(cfg)
         elif cfg.type == "simple":
             self._simple_message_queue_server = SimpleMessageQueueServer(cfg)
-            return SimpleMessageQueue(cfg)  # type: ignore
+            return SimpleMessageQueue(cfg)
         elif cfg.type == "solace":
-            return SolaceMessageQueue(cfg)  # type: ignore
+            return SolaceMessageQueue(cfg)
         else:
             msg = f"Unsupported message queue: {cfg.type}"
             raise ValueError(msg)

--- a/llama_deploy/control_plane/base.py
+++ b/llama_deploy/control_plane/base.py
@@ -6,7 +6,7 @@ from llama_deploy.message_consumers.base import (
     StartConsumingCallable,
 )
 from llama_deploy.message_publishers.publisher import MessageQueuePublisherMixin
-from llama_deploy.message_queues.base import BaseMessageQueue
+from llama_deploy.message_queues.base import AbstractMessageQueue
 from llama_deploy.types import (
     ServiceDefinition,
     SessionDefinition,
@@ -29,7 +29,7 @@ class BaseControlPlane(MessageQueuePublisherMixin, ABC):
 
     @property
     @abstractmethod
-    def message_queue(self) -> BaseMessageQueue:
+    def message_queue(self) -> AbstractMessageQueue:
         """Return associated message queue."""
 
     @abstractmethod

--- a/llama_deploy/control_plane/server.py
+++ b/llama_deploy/control_plane/server.py
@@ -18,7 +18,7 @@ from llama_deploy.message_consumers.base import (
 )
 from llama_deploy.message_consumers.callable import CallableMessageConsumer
 from llama_deploy.message_consumers.remote import RemoteMessageConsumer
-from llama_deploy.message_queues.base import BaseMessageQueue, PublishCallback
+from llama_deploy.message_queues.base import AbstractMessageQueue, PublishCallback
 from llama_deploy.messages.base import QueueMessage
 from llama_deploy.orchestrators import SimpleOrchestrator, SimpleOrchestratorConfig
 from llama_deploy.orchestrators.base import BaseOrchestrator
@@ -51,7 +51,7 @@ class ControlPlaneServer(BaseControlPlane):
     - Launching the control plane server.
 
     Args:
-        message_queue (BaseMessageQueue): Message queue for the system.
+        message_queue (AbstractMessageQueue): Message queue for the system.
         orchestrator (BaseOrchestrator): Orchestrator for the system.
         publish_callback (Optional[PublishCallback], optional): Callback for publishing messages. Defaults to None.
         state_store (Optional[BaseKVStore], optional): State store for the system. Defaults to None.
@@ -80,7 +80,7 @@ class ControlPlaneServer(BaseControlPlane):
 
     def __init__(
         self,
-        message_queue: BaseMessageQueue,
+        message_queue: AbstractMessageQueue,
         orchestrator: BaseOrchestrator | None = None,
         publish_callback: PublishCallback | None = None,
         state_store: BaseKVStore | None = None,
@@ -226,7 +226,7 @@ class ControlPlaneServer(BaseControlPlane):
         )
 
     @property
-    def message_queue(self) -> BaseMessageQueue:
+    def message_queue(self) -> AbstractMessageQueue:
         return self._message_queue
 
     @property

--- a/llama_deploy/deploy/deploy.py
+++ b/llama_deploy/deploy/deploy.py
@@ -8,9 +8,9 @@ from pydantic_settings import BaseSettings
 from llama_deploy.control_plane.server import ControlPlaneConfig, ControlPlaneServer
 from llama_deploy.deploy.network_workflow import NetworkServiceManager
 from llama_deploy.message_queues import (
+    AbstractMessageQueue,
     AWSMessageQueue,
     AWSMessageQueueConfig,
-    BaseMessageQueue,
     KafkaMessageQueue,
     KafkaMessageQueueConfig,
     RabbitMQMessageQueue,
@@ -60,19 +60,19 @@ def _get_message_queue_config(config_dict: dict) -> BaseSettings:
         raise ValueError(f"Unknown message queue: {key}")
 
 
-def _get_message_queue_client(config: BaseSettings) -> BaseMessageQueue:
+def _get_message_queue_client(config: BaseSettings) -> AbstractMessageQueue:
     if isinstance(config, SimpleMessageQueueConfig):
-        return SimpleMessageQueue(config)  # type: ignore
+        return SimpleMessageQueue(config)
     elif isinstance(config, AWSMessageQueueConfig):
-        return AWSMessageQueue(config)  # type: ignore
+        return AWSMessageQueue(config)
     elif isinstance(config, KafkaMessageQueueConfig):
-        return KafkaMessageQueue(config)  # type: ignore
+        return KafkaMessageQueue(config)
     elif isinstance(config, RabbitMQMessageQueueConfig):
-        return RabbitMQMessageQueue(config)  # type: ignore
+        return RabbitMQMessageQueue(config)
     elif isinstance(config, RedisMessageQueueConfig):
-        return RedisMessageQueue(config)  # type: ignore
+        return RedisMessageQueue(config)
     elif isinstance(config, SolaceMessageQueueConfig):
-        return SolaceMessageQueue(config)  # type: ignore
+        return SolaceMessageQueue(config)
     else:
         raise ValueError(f"Invalid message queue config: {config}")
 

--- a/llama_deploy/message_publishers/publisher.py
+++ b/llama_deploy/message_publishers/publisher.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
-from llama_deploy.message_queues.base import BaseMessageQueue, PublishCallback
+from llama_deploy.message_queues.base import AbstractMessageQueue, PublishCallback
 from llama_deploy.messages.base import QueueMessage
 
 
@@ -21,7 +21,7 @@ class MessageQueuePublisherMixin(ABC):
 
     @property
     @abstractmethod
-    def message_queue(self) -> BaseMessageQueue: ...
+    def message_queue(self) -> AbstractMessageQueue: ...
 
     @property
     def publish_callback(self) -> Optional[PublishCallback]:

--- a/llama_deploy/message_queues/__init__.py
+++ b/llama_deploy/message_queues/__init__.py
@@ -3,7 +3,7 @@ from llama_deploy.message_queues.apache_kafka import (
     KafkaMessageQueueConfig,
 )
 from llama_deploy.message_queues.aws import AWSMessageQueue, AWSMessageQueueConfig
-from llama_deploy.message_queues.base import AbstractMessageQueue, BaseMessageQueue
+from llama_deploy.message_queues.base import AbstractMessageQueue
 from llama_deploy.message_queues.rabbitmq import (
     RabbitMQMessageQueue,
     RabbitMQMessageQueueConfig,
@@ -23,7 +23,6 @@ from llama_deploy.message_queues.solace import (
 
 __all__ = [
     "AbstractMessageQueue",
-    "BaseMessageQueue",
     "KafkaMessageQueue",
     "KafkaMessageQueueConfig",
     "RabbitMQMessageQueue",

--- a/llama_deploy/message_queues/aws.py
+++ b/llama_deploy/message_queues/aws.py
@@ -298,12 +298,11 @@ class AWSMessageQueue(AbstractMessageQueue):
                     logger.error(f"Could not delete SNS topic {topic.name}: {e}")
 
     async def register_consumer(
-        self, consumer: BaseMessageQueueConsumer, topic: str | None = None
+        self, consumer: BaseMessageQueueConsumer, topic: str
     ) -> StartConsumingCallable:
         """Register a new consumer."""
         from botocore.exceptions import ClientError
 
-        topic = topic or consumer.message_type
         _topic = await self._create_sns_topic(topic_name=topic)
         queue = await self._create_sqs_queue(queue_name=topic)
         await self._subscribe_queue_to_topic(queue=queue, topic=_topic)
@@ -348,12 +347,5 @@ class AWSMessageQueue(AbstractMessageQueue):
         """Deregister a consumer.
 
         Not implemented for this integration, as SQS does not maintain persistent consumers.
-        """
-        pass
-
-    async def processing_loop(self) -> None:
-        """A loop for getting messages from queues and sending to consumer.
-
-        Not relevant for this class.
         """
         pass

--- a/llama_deploy/message_queues/base.py
+++ b/llama_deploy/message_queues/base.py
@@ -10,7 +10,7 @@ from typing import (
     Sequence,
 )
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 from llama_deploy.message_consumers.base import (
     BaseMessageQueueConsumer,
@@ -57,7 +57,7 @@ class AbstractMessageQueue(ABC):
 
     @abstractmethod
     async def register_consumer(
-        self, consumer: BaseMessageQueueConsumer, topic: str | None = None
+        self, consumer: BaseMessageQueueConsumer, topic: str
     ) -> StartConsumingCallable:
         """Register consumer to start consuming messages."""
 
@@ -80,14 +80,3 @@ class AbstractMessageQueue(ABC):
     @abstractmethod
     def as_config(self) -> BaseModel:
         """Returns the config dict to reconstruct the message queue."""
-
-
-class BaseMessageQueue(BaseModel, AbstractMessageQueue):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-
-    @abstractmethod
-    async def processing_loop(self) -> None:
-        """The processing loop for the service."""

--- a/llama_deploy/message_queues/rabbitmq.py
+++ b/llama_deploy/message_queues/rabbitmq.py
@@ -175,7 +175,7 @@ class RabbitMQMessageQueue(AbstractMessageQueue):
             logger.info(f"published message {message.id_} to {topic}")
 
     async def register_consumer(
-        self, consumer: BaseMessageQueueConsumer, topic: str | None = None
+        self, consumer: BaseMessageQueueConsumer, topic: str
     ) -> StartConsumingCallable:
         """Register a new consumer."""
         from aio_pika import Channel, ExchangeType, IncomingMessage, Queue
@@ -243,13 +243,6 @@ class RabbitMQMessageQueue(AbstractMessageQueue):
 
         Not implemented for this integration, as once the connection/channel is
         closed, the consumer is deregistered.
-        """
-        pass
-
-    async def processing_loop(self) -> None:
-        """A loop for getting messages from queues and sending to consumer.
-
-        Not relevant for this class.
         """
         pass
 

--- a/llama_deploy/message_queues/redis.py
+++ b/llama_deploy/message_queues/redis.py
@@ -85,12 +85,9 @@ class RedisMessageQueue(AbstractMessageQueue):
         return result
 
     async def register_consumer(
-        self, consumer: BaseMessageQueueConsumer, topic: str | None = None
+        self, consumer: BaseMessageQueueConsumer, topic: str
     ) -> StartConsumingCallable:
         """Register a new consumer."""
-        if topic is None:
-            raise ValueError("Topic must be a valid string")
-
         if consumer.id_ in self._consumers:
             logger.debug(
                 f"Consumer {consumer.id_} already registered for topic {topic}",
@@ -137,13 +134,6 @@ class RedisMessageQueue(AbstractMessageQueue):
             logger.info(
                 f"Deregistered consumer {consumer.id_} for topic {consumer_metadata.topic}",
             )
-
-    async def processing_loop(self) -> None:
-        """A loop for getting messages from queues and sending to consumer.
-
-        Not relevant for this class as Redis uses pub/sub model.
-        """
-        pass  # pragma: no cover
 
     async def cleanup(self, *args: Any, **kwargs: dict[str, Any]) -> None:
         """Perform any cleanup before shutting down."""

--- a/llama_deploy/message_queues/simple/client.py
+++ b/llama_deploy/message_queues/simple/client.py
@@ -33,12 +33,10 @@ class SimpleMessageQueue(AbstractMessageQueue):
         return result
 
     async def register_consumer(
-        self, consumer: BaseMessageQueueConsumer, topic: str | None = None
+        self, consumer: BaseMessageQueueConsumer, topic: str
     ) -> StartConsumingCallable:
         """Register a new consumer."""
         # register topic
-        topic = topic or consumer.message_type
-
         if topic not in self._consumers:
             # call the server to create it
             url = f"{self._config.base_url}topics/{topic}"

--- a/llama_deploy/message_queues/solace.py
+++ b/llama_deploy/message_queues/solace.py
@@ -311,12 +311,9 @@ class SolaceMessageQueue(AbstractMessageQueue):
         return
 
     async def register_consumer(
-        self, consumer: BaseMessageQueueConsumer, topic: str | None = None
+        self, consumer: BaseMessageQueueConsumer, topic: str
     ) -> StartConsumingCallable:
         """Register a new consumer."""
-        if topic is None:
-            raise ValueError("Topic must be a valid string")
-
         try:
             from solace.messaging.errors.pubsubplus_client_error import (
                 IllegalStateError,
@@ -374,10 +371,6 @@ class SolaceMessageQueue(AbstractMessageQueue):
             raise
         finally:
             self._persistent_receiver.terminate()  # type:ignore
-
-    async def processing_loop(self) -> None:
-        """A loop for getting messages from queues and sending to consumer."""
-        pass
 
     async def cleanup(self, *args: Any, **kwargs: Dict[str, Any]) -> None:
         """Perform any clean up of queues and exchanges."""

--- a/llama_deploy/services/workflow.py
+++ b/llama_deploy/services/workflow.py
@@ -24,7 +24,7 @@ from llama_deploy.message_consumers.base import BaseMessageQueueConsumer
 from llama_deploy.message_consumers.callable import CallableMessageConsumer
 from llama_deploy.message_consumers.remote import RemoteMessageConsumer
 from llama_deploy.message_publishers.publisher import PublishCallback
-from llama_deploy.message_queues.base import BaseMessageQueue
+from llama_deploy.message_queues.base import AbstractMessageQueue
 from llama_deploy.messages.base import QueueMessage
 from llama_deploy.services.base import BaseService
 from llama_deploy.types import (
@@ -125,7 +125,7 @@ class WorkflowService(BaseService):
     internal_port: Optional[int] = None
     raise_exceptions: bool = False
 
-    _message_queue: BaseMessageQueue = PrivateAttr()
+    _message_queue: AbstractMessageQueue = PrivateAttr()
     _app: FastAPI = PrivateAttr()
     _publisher_id: str = PrivateAttr()
     _publish_callback: Optional[PublishCallback] = PrivateAttr()
@@ -136,7 +136,7 @@ class WorkflowService(BaseService):
     def __init__(
         self,
         workflow: Workflow,
-        message_queue: BaseMessageQueue,
+        message_queue: AbstractMessageQueue,
         running: bool = True,
         description: str = "Component Server",
         service_name: str = "default_workflow_service",
@@ -196,7 +196,7 @@ class WorkflowService(BaseService):
         )
 
     @property
-    def message_queue(self) -> BaseMessageQueue:
+    def message_queue(self) -> AbstractMessageQueue:
         """Message queue."""
         return self._message_queue
 

--- a/tests/message_queues/simple/test_server.py
+++ b/tests/message_queues/simple/test_server.py
@@ -45,11 +45,11 @@ async def test_roundtrip(message_queue_server: SimpleMessageQueueServer) -> None
     mq = SimpleMessageQueue(SimpleMessageQueueConfig(raise_exceptions=True))
 
     consumer_one = MockMessageConsumer(message_type="test_one")
-    consumer_one_fn = await mq.register_consumer(consumer_one)
+    consumer_one_fn = await mq.register_consumer(consumer_one, "test_one")
     consumer_one_task = asyncio.create_task(consumer_one_fn())
 
     consumer_two = MockMessageConsumer(message_type="test_two")
-    consumer_two_fn = await mq.register_consumer(consumer_two)
+    consumer_two_fn = await mq.register_consumer(consumer_two, "test_two")
     consumer_two_task = asyncio.create_task(consumer_two_fn())
 
     # Act

--- a/tests/message_queues/test_rabbitmq.py
+++ b/tests/message_queues/test_rabbitmq.py
@@ -48,7 +48,7 @@ async def test_register_consumer() -> None:
         "llama_deploy.message_queues.rabbitmq._establish_connection"
     ) as connection:
         mq = RabbitMQMessageQueue()
-        consumer_func = await mq.register_consumer(MagicMock())
+        consumer_func = await mq.register_consumer(MagicMock(), "test_topic")
         task = asyncio.create_task(consumer_func())
         await asyncio.sleep(0)
         task.cancel()


### PR DESCRIPTION
Fixes #359 

Final step of the refactoring, removing `BaseMessageQueue` in favor of `AbstractMessageQueue`.
Also in this PR:
- removed the optionality for `topic` that was for backward compatibility with `BaseMessageQueue`
- removed the unused abstract method `processing_loop`