### PR TITLE
feat: support HTTPS control plane URL

### DIFF
--- a/llama_deploy/control_plane/config.py
+++ b/llama_deploy/control_plane/config.py
@@ -36,9 +36,15 @@ class ControlPlaneConfig(BaseSettings):
         default=None,
         description="The connection URI of the database where to store state. If None, SimpleKVStore will be used",
     )
+    use_tls: bool = Field(
+        default=False,
+        description="Use TLS (HTTPS) to communicate with the control plane",
+    )
 
     @property
     def url(self) -> str:
+        if self.use_tls:
+            return f"https://{self.host}:{self.port}"
         return f"http://{self.host}:{self.port}"
 
 

--- a/llama_deploy/deploy/deploy.py
+++ b/llama_deploy/deploy/deploy.py
@@ -201,9 +201,6 @@ async def deploy_workflow(
     await asyncio.sleep(1)
 
     # register to control plane
-    control_plane_url = (
-        f"http://{control_plane_config.host}:{control_plane_config.port}"
-    )
     await service.register_to_control_plane(control_plane_url)
 
     # register to message queue


### PR DESCRIPTION
This change introduces a new configuration option "USE_TLS" for the ControlPlaneConfig. When True this will render the control plane URL with the HTTPS scheme instead of HTTP.

Fixes: #420