### PR TITLE
fix: avoid cluttering logs with simple message queue polling

### DIFF
--- a/tests/message_queues/simple/test_server.py
+++ b/tests/message_queues/simple/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import pytest
 from fastapi.testclient import TestClient
@@ -8,6 +9,7 @@ from llama_deploy.message_queues.simple import (
     SimpleMessageQueueConfig,
     SimpleMessageQueueServer,
 )
+from llama_deploy.message_queues.simple.server import MessagesPollFilter
 from llama_deploy.messages.base import QueueMessage
 
 from .conftest import MockMessageConsumer
@@ -74,3 +76,28 @@ async def test_roundtrip(message_queue_server: SimpleMessageQueueServer) -> None
     # Assert
     assert ["1", "2"] == [m.id_ for m in consumer_one.processed_messages]
     assert ["3"] == [m.id_ for m in consumer_two.processed_messages]
+
+
+def test_log_filter() -> None:
+    f = MessagesPollFilter()
+    r = logging.LogRecord(
+        "",
+        logging.INFO,
+        "",
+        42,
+        "GET /messages/llama_deploy.control_plane HTTP/1.1",
+        None,
+        None,
+    )
+    assert f.filter(r) is False
+
+    r = logging.LogRecord(
+        "",
+        logging.INFO,
+        "",
+        42,
+        "POST /messages/llama_deploy.control_plane HTTP/1.1",
+        None,
+        None,
+    )
+    assert f.filter(r) is True


### PR DESCRIPTION
Fixes #428 

After the refactoring, the SimpleMessageQueue behaves like a pubsub system with the client polling for messages, similar to Redis for example. Using plain HTTP calls as the pubsub protocol, the client keeps `GET`ting the endpoint on the server to get messages (if any) for the whole application lifetime, and uvicorn happily fills the access logs with noise.

This PR filters out polling requests to the `/messages` endpoint from the access logs.