### PR TITLE
ci: use different queues to allow tests to run in parallel

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -36,4 +36,5 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          TOPIC_PREFIX: ${{ matrix.python-version }}
         run: poetry run pytest e2e_tests/

--- a/e2e_tests/message_queues/aws/conftest.py
+++ b/e2e_tests/message_queues/aws/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import multiprocessing
+import os
 import time
 
 import pytest
@@ -20,7 +21,13 @@ def mq():
     return AWSMessageQueue()
 
 
-def run_workflow_one():
+@pytest.fixture
+def topic_prefix() -> str:
+    """Use different SQS queues to allow tests to run in parallel"""
+    return os.environ.get("TOPIC_PREFIX", "")
+
+
+def run_workflow_one(topic_prefix):
     asyncio.run(
         deploy_workflow(
             BasicWorkflow(timeout=10, name="Workflow one"),
@@ -29,12 +36,12 @@ def run_workflow_one():
                 port=8003,
                 service_name="basic",
             ),
-            ControlPlaneConfig(topic_namespace="core_one", port=8001),
+            ControlPlaneConfig(topic_namespace=f"{topic_prefix}core_one", port=8001),
         )
     )
 
 
-def run_workflow_two():
+def run_workflow_two(topic_prefix):
     asyncio.run(
         deploy_workflow(
             BasicWorkflow(timeout=10, name="Workflow two"),
@@ -43,24 +50,24 @@ def run_workflow_two():
                 port=8004,
                 service_name="basic",
             ),
-            ControlPlaneConfig(topic_namespace="core_two", port=8002),
+            ControlPlaneConfig(topic_namespace=f"{topic_prefix}core_two", port=8002),
         )
     )
 
 
-def run_core_one():
+def run_core_one(topic_prefix):
     asyncio.run(
         deploy_core(
-            ControlPlaneConfig(topic_namespace="core_one", port=8001),
+            ControlPlaneConfig(topic_namespace=f"{topic_prefix}core_one", port=8001),
             AWSMessageQueueConfig(),
         )
     )
 
 
-def run_core_two():
+def run_core_two(topic_prefix):
     asyncio.run(
         deploy_core(
-            ControlPlaneConfig(topic_namespace="core_two", port=8002),
+            ControlPlaneConfig(topic_namespace=f"{topic_prefix}core_two", port=8002),
             AWSMessageQueueConfig(),
         )
     )

--- a/e2e_tests/message_queues/aws/conftest.py
+++ b/e2e_tests/message_queues/aws/conftest.py
@@ -24,7 +24,7 @@ def mq():
 @pytest.fixture
 def topic_prefix() -> str:
     """Use different SQS queues to allow tests to run in parallel"""
-    return os.environ.get("TOPIC_PREFIX", "")
+    return os.environ.get("TOPIC_PREFIX", "").replace(".", "_")
 
 
 def run_workflow_one(topic_prefix):

--- a/e2e_tests/message_queues/aws/test_message_queue.py
+++ b/e2e_tests/message_queues/aws/test_message_queue.py
@@ -13,8 +13,9 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.asyncio
-async def test_roundtrip(mq):
+async def test_roundtrip(mq, topic_prefix):
     received_messages = []
+    topic = f"{topic_prefix}test"
 
     # register a consumer
     def message_handler(message: QueueMessage) -> None:
@@ -23,13 +24,13 @@ async def test_roundtrip(mq):
     test_consumer = CallableMessageConsumer(
         message_type="test_message", handler=message_handler
     )
-    start_consuming_callable = await mq.register_consumer(test_consumer, topic="test")
+    start_consuming_callable = await mq.register_consumer(test_consumer, topic=topic)
     t = asyncio.create_task(start_consuming_callable())
     await asyncio.sleep(1)
 
     # produce a message
     test_message = QueueMessage(type="test_message", data={"message": "this is a test"})
-    await mq.publish(test_message, topic="test")
+    await mq.publish(test_message, topic=topic)
     await asyncio.sleep(1)
 
     t.cancel()


### PR DESCRIPTION
Parallel instances of e2e test runs will try to write to the same SQS queue and mess up the results.

With this PR we use different queues for each element in the matrix workflow.