### PR TITLE
fix: remove problematic root_path

### DIFF
--- a/llama_deploy/apiserver/app.py
+++ b/llama_deploy/apiserver/app.py
@@ -2,16 +2,16 @@ import logging
 import os
 
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
-from .routers import status_router, deployments_router
+from .routers import deployments_router, status_router
 from .server import lifespan
 
 logger = logging.getLogger("uvicorn.info")
 
 
-app = FastAPI(root_path="/", lifespan=lifespan)
+app = FastAPI(lifespan=lifespan)
 
 # Configure CORS middleware if the environment variable is set
 if not os.environ.get("DISABLE_CORS", False):


### PR DESCRIPTION
From #431, passing `root_path="/"` causes problems on some platforms. Since it's not a good practice to pass `/` anyways, let's remove it and see if it fixes the linked issue.