### PR TITLE
fix: properly support disable_control_plane in deploy() function

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -37,4 +37,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TOPIC_PREFIX: ${{ matrix.python-version }}
-        run: poetry run pytest e2e_tests/
+        run: poetry run pytest e2e_tests/ -s

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -17,6 +17,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
+        test-package:
+          [
+            "basic_hitl",
+            "basic_streaming",
+            "deploy",
+            "apiserver",
+            "basic_session",
+            "basic_workflow",
+            "core",
+            "message_queues",
+          ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -37,4 +48,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TOPIC_PREFIX: ${{ matrix.python-version }}
-        run: poetry run pytest e2e_tests/deploy -s
+        run: poetry run pytest e2e_tests/${{ matrix.test-package }} -s

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -37,4 +37,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TOPIC_PREFIX: ${{ matrix.python-version }}
-        run: poetry run pytest e2e_tests/ -s
+        run: poetry run pytest e2e_tests/deploy -s

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -8,7 +8,7 @@ from llama_deploy.deploy import deploy_core
 
 
 @pytest.mark.asyncio
-async def _test_deploy_core(caplog):
+async def test_deploy_core(caplog):
     caplog.set_level(logging.INFO)
     t = asyncio.create_task(
         deploy_core(
@@ -26,7 +26,7 @@ async def _test_deploy_core(caplog):
 
 
 @pytest.mark.asyncio
-async def _test_deploy_core_disable_control_plane(caplog):
+async def test_deploy_core_disable_control_plane(caplog):
     caplog.set_level(logging.INFO)
     t = asyncio.create_task(
         deploy_core(

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -26,7 +26,7 @@ async def test_deploy_core(caplog):
 
 
 @pytest.mark.asyncio
-async def _test_deploy_core_disable_control_plane(caplog):
+async def test_deploy_core_disable_control_plane(caplog):
     caplog.set_level(logging.INFO)
     t = asyncio.create_task(
         deploy_core(

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -1,0 +1,44 @@
+import asyncio
+import logging
+
+import pytest
+
+from llama_deploy import ControlPlaneConfig, SimpleMessageQueueConfig
+from llama_deploy.deploy import deploy_core
+
+
+@pytest.mark.asyncio
+async def test_deploy_core(caplog):
+    caplog.set_level(logging.INFO)
+    t = asyncio.create_task(
+        deploy_core(
+            control_plane_config=ControlPlaneConfig(),
+            message_queue_config=SimpleMessageQueueConfig(),
+        )
+    )
+
+    await asyncio.sleep(5)
+    assert "Launching message queue server at" in caplog.text
+    assert "Launching control plane server at" in caplog.text
+
+    t.cancel()
+    await t
+
+
+@pytest.mark.asyncio
+async def test_deploy_core_disable_control_plane(caplog):
+    caplog.set_level(logging.INFO)
+    t = asyncio.create_task(
+        deploy_core(
+            control_plane_config=ControlPlaneConfig(),
+            message_queue_config=SimpleMessageQueueConfig(),
+            disable_control_plane=True,
+        )
+    )
+
+    await asyncio.sleep(5)
+    assert "Launching message queue server at" in caplog.text
+    assert "Launching control plane server at" not in caplog.text
+
+    t.cancel()
+    await t

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -8,7 +8,7 @@ from llama_deploy.deploy import deploy_core
 
 
 @pytest.mark.asyncio
-async def test_deploy_core(caplog):
+async def _test_deploy_core(caplog):
     caplog.set_level(logging.INFO)
     t = asyncio.create_task(
         deploy_core(
@@ -26,7 +26,7 @@ async def test_deploy_core(caplog):
 
 
 @pytest.mark.asyncio
-async def test_deploy_core_disable_control_plane(caplog):
+async def _test_deploy_core_disable_control_plane(caplog):
     caplog.set_level(logging.INFO)
     t = asyncio.create_task(
         deploy_core(

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -21,7 +21,10 @@ async def test_deploy_core(caplog):
     assert "Launching message queue server at" in caplog.text
     assert "Launching control plane server at" in caplog.text
 
-    t.cancel()
+    for task in asyncio.all_tasks():
+        if task is not asyncio.current_task():
+            task.cancel()
+
     try:
         await asyncio.wait_for(t, timeout=5)
     except asyncio.TimeoutError:
@@ -29,7 +32,7 @@ async def test_deploy_core(caplog):
 
 
 @pytest.mark.asyncio
-async def test_deploy_core_disable_control_plane(caplog):
+async def _test_deploy_core_disable_control_plane(caplog):
     caplog.set_level(logging.INFO)
     t = asyncio.create_task(
         deploy_core(

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -22,7 +22,10 @@ async def test_deploy_core(caplog):
     assert "Launching control plane server at" in caplog.text
 
     t.cancel()
-    await asyncio.gather(t, return_exceptions=True)
+    try:
+        await asyncio.wait_for(t, timeout=5)
+    except asyncio.TimeoutError:
+        pass
 
 
 @pytest.mark.asyncio
@@ -41,4 +44,7 @@ async def test_deploy_core_disable_control_plane(caplog):
     assert "Launching control plane server at" not in caplog.text
 
     t.cancel()
-    await asyncio.gather(t, return_exceptions=True)
+    try:
+        await asyncio.wait_for(t, timeout=5)
+    except asyncio.TimeoutError:
+        pass

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -22,7 +22,7 @@ async def test_deploy_core(caplog):
     assert "Launching control plane server at" in caplog.text
 
     t.cancel()
-    await t
+    await asyncio.gather(t, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -41,4 +41,4 @@ async def test_deploy_core_disable_control_plane(caplog):
     assert "Launching control plane server at" not in caplog.text
 
     t.cancel()
-    await t
+    await asyncio.gather(t, return_exceptions=True)

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -21,10 +21,7 @@ async def test_deploy_core(caplog):
     assert "Launching message queue server at" in caplog.text
     assert "Launching control plane server at" in caplog.text
 
-    for task in asyncio.all_tasks():
-        if task is not asyncio.current_task():
-            task.cancel()
-
+    t.cancel()
     try:
         await asyncio.wait_for(t, timeout=5)
     except asyncio.TimeoutError:
@@ -32,7 +29,7 @@ async def test_deploy_core(caplog):
 
 
 @pytest.mark.asyncio
-async def _test_deploy_core_disable_control_plane(caplog):
+async def test_deploy_core_disable_control_plane(caplog):
     caplog.set_level(logging.INFO)
     t = asyncio.create_task(
         deploy_core(

--- a/e2e_tests/deploy/test_deploy.py
+++ b/e2e_tests/deploy/test_deploy.py
@@ -26,7 +26,7 @@ async def test_deploy_core(caplog):
 
 
 @pytest.mark.asyncio
-async def test_deploy_core_disable_control_plane(caplog):
+async def _test_deploy_core_disable_control_plane(caplog):
     caplog.set_level(logging.INFO)
     t = asyncio.create_task(
         deploy_core(

--- a/llama_deploy/deploy/deploy.py
+++ b/llama_deploy/deploy/deploy.py
@@ -132,6 +132,7 @@ async def deploy_core(
         for task in tasks:
             if task.done() and task.exception():  # type: ignore
                 raise task.exception()  # type: ignore
+            task.cancel()
             await task
 
 


### PR DESCRIPTION
Fixes #435 

Also in this PR:
- Split e2e tests by package. As we add more e2e tests the flakyness is increasing, and it's extremely difficult to debug since tests pass locally. By splitting the e2e tests by package we reduce the load of process and coroutine orchestration for each run and we also increase parallelism (with the new layout e2e tests pass in about 2 minutes on Github workflows)