### PR TITLE
feat: make apiserver host and port configurable via env vars

### DIFF
--- a/e2e_tests/apiserver/test_service_entrypoint.py
+++ b/e2e_tests/apiserver/test_service_entrypoint.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+import time
+
+import requests
+
+
+def test_apiserver_entrypoint():
+    # Customize host and port
+    env = os.environ.copy()
+    env["LLAMA_DEPLOY_APISERVER_HOST"] = "localhost"
+    env["LLAMA_DEPLOY_APISERVER_PORT"] = "4502"
+    # Start the API server as a subprocess
+    process = subprocess.Popen(
+        ["python", "-m", "llama_deploy.apiserver"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+    try:
+        # Wait a bit for the server to start
+        time.sleep(2)
+
+        response = requests.get("http://localhost:4502/status")
+        assert response.status_code == 200
+    finally:
+        # Clean up: terminate the server process
+        process.terminate()
+        process.wait()

--- a/llama_deploy/apiserver/__main__.py
+++ b/llama_deploy/apiserver/__main__.py
@@ -1,5 +1,10 @@
+import os
+
 import uvicorn
 
-
 if __name__ == "__main__":
-    uvicorn.run("llama_deploy.apiserver:app", host="0.0.0.0", port=4501)
+    uvicorn.run(
+        "llama_deploy.apiserver:app",
+        host=os.environ.get("LLAMA_DEPLOY_APISERVER_HOST", "0.0.0.0"),
+        port=int(os.environ.get("LLAMA_DEPLOY_APISERVER_PORT", 4501)),
+    )


### PR DESCRIPTION
At the moment host and port for the apiserver are hardcoded in the entrypoint `__main__.py` and the only alternative to customize them is to invoke uvicorn manually.

With this PR host and port can be set from env vars like this:
`LLAMA_DEPLOY_APISERVER_PORT=8080 LLAMA_DEPLOY_APISERVER_HOST=localhost python -m llama_deploy.apiserver`

Useful for customizing the LlamaDeploy docker image with less code.