### PR TITLE
fix: launch only one SimpleMessageQueueServer per API Server instance

### DIFF
--- a/e2e_tests/apiserver/conftest.py
+++ b/e2e_tests/apiserver/conftest.py
@@ -19,7 +19,9 @@ def apiserver():
 
     yield
 
-    p.kill()
+    p.terminate()
+    p.join()
+    p.close()
 
 
 @pytest.fixture

--- a/e2e_tests/apiserver/deployments/deployment_env_git.yml
+++ b/e2e_tests/apiserver/deployments/deployment_env_git.yml
@@ -3,8 +3,6 @@ name: EnvironmentVariablesGit
 control-plane:
   port: 8000
 
-default-service: test_env_workflow
-
 services:
   workflow_git:
     name: Git Workflow
@@ -12,8 +10,8 @@ services:
       type: git
       name: https://github.com/run-llama/llama_deploy.git
     env:
-      VAR_1: x  # this gets overwritten because VAR_1 also exists in the provided .env
+      VAR_1: x # this gets overwritten because VAR_1 also exists in the provided .env
       VAR_2: y
     env-files:
-      - tests/apiserver/data/.env  # relative to source path
+      - tests/apiserver/data/.env # relative to source path
     path: tests/apiserver/data/workflow:env_reader_workflow

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -58,7 +58,6 @@ class Deployment:
         """
         self._name = config.name
         self._path = root_path / config.name
-        self._simple_message_queue_server: SimpleMessageQueueServer | None = None
         self._queue_client = self._load_message_queue_client(config.message_queue)
         self._control_plane_config = config.control_plane
         self._control_plane = ControlPlaneServer(
@@ -100,16 +99,6 @@ class Deployment:
         """
         tasks = []
         self._running = True
-
-        # Spawn SimpleMessageQueue if needed
-        if self._simple_message_queue_server:
-            # If SimpleMessageQueue was selected in the config file we take care of running the task
-            tasks.append(
-                asyncio.create_task(self._simple_message_queue_server.launch_server())
-            )
-            # the other components need the queue to run in order to start, give the queue some time to start
-            # FIXME: having to await a magic number of seconds is very brittle, we should rethink the bootstrap process
-            await asyncio.sleep(1)
 
         # Control Plane
         cp_consumer_fn = await self._control_plane.register_to_message_queue()
@@ -291,7 +280,6 @@ class Deployment:
         elif cfg.type == "redis":
             return RedisMessageQueue(cfg)
         elif cfg.type == "simple":
-            self._simple_message_queue_server = SimpleMessageQueueServer(cfg)
             return SimpleMessageQueue(cfg)
         elif cfg.type == "solace":
             return SolaceMessageQueue(cfg)
@@ -328,6 +316,7 @@ class Manager:
         self._max_deployments = max_deployments
         self._pool = ThreadPool(processes=max_deployments)
         self._last_control_plane_port = 8002
+        self._simple_message_queue_server: asyncio.Task | None = None
 
     @property
     def deployment_names(self) -> list[str]:
@@ -344,7 +333,9 @@ class Manager:
             # Waits indefinitely since `event` will never be set
             await event.wait()
         except asyncio.CancelledError:
-            pass
+            if self._simple_message_queue_server is not None:
+                self._simple_message_queue_server.cancel()
+                await self._simple_message_queue_server
 
     async def deploy(self, config: Config, reload: bool = False) -> None:
         """Creates a Deployment instance and starts the relative runtime.
@@ -370,6 +361,21 @@ class Manager:
 
             # Set the control plane TCP port in the config where not specified
             self._assign_control_plane_address(config)
+
+            # Get the message queue configuration
+            msg_queue = config.message_queue or SimpleMessageQueueConfig()
+
+            # Spawn SimpleMessageQueue server if needed
+            if (
+                isinstance(msg_queue, SimpleMessageQueueConfig)
+                and self._simple_message_queue_server is None
+            ):
+                self._simple_message_queue_server = asyncio.create_task(
+                    SimpleMessageQueueServer(msg_queue).launch_server()
+                )
+                # the other components need the queue to run in order to start, give the queue some time to start
+                # FIXME: having to await a magic number of seconds is very brittle, we should rethink the bootstrap process
+                await asyncio.sleep(3)
 
             deployment = Deployment(config=config, root_path=self._deployments_path)
             self._deployments[config.name] = deployment

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -12,9 +12,7 @@ from llama_deploy.apiserver.config_parser import (
 )
 from llama_deploy.apiserver.deployment import Deployment, DeploymentError, Manager
 from llama_deploy.control_plane import ControlPlaneServer
-from llama_deploy.message_queues import (
-    SimpleMessageQueue,
-)
+from llama_deploy.message_queues import AWSMessageQueueConfig, SimpleMessageQueue
 
 
 def test_deployment_ctor(data_path: Path) -> None:
@@ -26,7 +24,6 @@ def test_deployment_ctor(data_path: Path) -> None:
         sm_dict["git"].sync.assert_called_once()
         assert d.name == "TestDeployment"
         assert d.path.name == "TestDeployment"
-        assert d._simple_message_queue_server is not None
         assert type(d._control_plane) is ControlPlaneServer
         assert len(d._workflow_services) == 1
         assert d.client is not None
@@ -176,6 +173,7 @@ def test_manager_ctor() -> None:
     assert len(m._deployments) == 0
     assert len(m.deployment_names) == 0
     assert m.get_deployment("foo") is None
+    assert m._simple_message_queue_server is None
 
 
 @pytest.mark.asyncio
@@ -206,6 +204,8 @@ async def test_manager_deploy_maximum_reached(data_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_manager_deploy(data_path: Path) -> None:
     config = Config.from_yaml(data_path / "git_service.yaml")
+    # Do not use SimpleMessageQueue here, to avoid starting the server
+    config.message_queue = AWSMessageQueueConfig()
     with mock.patch(
         "llama_deploy.apiserver.deployment.Deployment"
     ) as mocked_deployment:


### PR DESCRIPTION
This fixes a subtle bug we had when creating multiple deployments on a single API Server instance, all using `SimpleMessageQueue`. Before we would start a server for each deployment, causing an error (address already in use). The API Server would still mostly work, but with an inconsistent state.

With this PR we move the logic from `Deployment` to the `Manager`, ensuring a single instance.