### PR TITLE
chore: refactor WorkflowService configuration

### DIFF
--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -171,9 +171,7 @@ class Deployment:
                 await wfs.register_to_control_plane(self._control_plane_config.url)
                 consumer_task = asyncio.create_task(consumer_fn())
                 # Make sure the service is up and running before proceeding
-                # TODO: add an `url` property to WorkflowService to compute the
-                # url and properly account for TLS usage
-                url = f"http://{wfs.host}:{wfs.port}/"
+                url = wfs.config.url
                 try:
                     async for attempt in AsyncRetrying(
                         wait=wait_exponential(min=1, max=10),
@@ -257,7 +255,7 @@ class Deployment:
                 WorkflowService(
                     workflow=workflow,
                     message_queue=self._queue_client,
-                    **workflow_config.model_dump(),
+                    config=workflow_config,
                 )
             )
 

--- a/llama_deploy/deploy/deploy.py
+++ b/llama_deploy/deploy/deploy.py
@@ -172,7 +172,7 @@ async def deploy_workflow(
     service = WorkflowService(
         workflow=workflow,
         message_queue=message_queue_client,
-        **workflow_config.model_dump(),
+        config=workflow_config,
     )
 
     service_task = asyncio.create_task(service.launch_server())

--- a/llama_deploy/services/base.py
+++ b/llama_deploy/services/base.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import httpx
-from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 from llama_deploy.control_plane.server import ControlPlaneConfig
 from llama_deploy.message_consumers.base import (
@@ -15,7 +14,7 @@ from llama_deploy.messages.base import QueueMessage
 from llama_deploy.types import ServiceDefinition
 
 
-class BaseService(MessageQueuePublisherMixin, ABC, BaseModel):
+class BaseService(MessageQueuePublisherMixin, ABC):
     """Base class for a service.
 
     The general structure of a service is as follows:
@@ -31,15 +30,19 @@ class BaseService(MessageQueuePublisherMixin, ABC, BaseModel):
     - A service can be registered to the message queue.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        name: str,
+        control_plane_url: str | None = None,  # deprecated
+        control_plane_config: ControlPlaneConfig = ControlPlaneConfig(),
+    ) -> None:
+        self._service_name = name
+        self._control_plane_config = control_plane_config
+        self._control_plane_url = control_plane_config.url
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-    service_name: str
-    _control_plane_url: str | None = PrivateAttr(default=None)
-    _control_plane_config: ControlPlaneConfig = PrivateAttr(
-        default=ControlPlaneConfig()
-    )
+    @property
+    def service_name(self) -> str:
+        return self._service_name
 
     @property
     @abstractmethod
@@ -98,19 +101,20 @@ class BaseService(MessageQueuePublisherMixin, ABC, BaseModel):
 
     async def get_session_state(self, session_id: str) -> dict[str, Any] | None:
         """Get the session state from the control plane."""
-        if not self._control_plane_url:
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self._control_plane_url}/sessions/{session_id}/state"
+                )
+                if response.status_code == 404:
+                    return None
+                else:
+                    response.raise_for_status()
+
+                return response.json()
+        except httpx.ConnectError:
+            # Let the service live without a control plane running
             return None
-
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                f"{self._control_plane_url}/sessions/{session_id}/state"
-            )
-            if response.status_code == 404:
-                return None
-            else:
-                response.raise_for_status()
-
-            return response.json()
 
     async def update_session_state(
         self, session_id: str, state: dict[str, Any]

--- a/llama_deploy/services/base.py
+++ b/llama_deploy/services/base.py
@@ -34,11 +34,11 @@ class BaseService(MessageQueuePublisherMixin, ABC):
         self,
         name: str,
         control_plane_url: str | None = None,  # deprecated
-        control_plane_config: ControlPlaneConfig = ControlPlaneConfig(),
+        control_plane_config: ControlPlaneConfig | None = None,
     ) -> None:
         self._service_name = name
-        self._control_plane_config = control_plane_config
-        self._control_plane_url = control_plane_config.url
+        self._control_plane_config = control_plane_config or ControlPlaneConfig()
+        self._control_plane_url = self._control_plane_config.url
 
     @property
     def service_name(self) -> str:

--- a/tests/services/test_workflow_service.py
+++ b/tests/services/test_workflow_service.py
@@ -11,7 +11,7 @@ from pydantic import PrivateAttr
 from llama_deploy.message_consumers import BaseMessageQueueConsumer
 from llama_deploy.message_queues import SimpleMessageQueue
 from llama_deploy.messages import QueueMessage
-from llama_deploy.services.workflow import WorkflowService
+from llama_deploy.services.workflow import WorkflowService, WorkflowServiceConfig
 from llama_deploy.types import CONTROL_PLANE_NAME, ActionTypes, TaskDefinition
 
 
@@ -73,10 +73,12 @@ async def test_workflow_service(
     workflow_service = WorkflowService(
         test_workflow,
         message_queue,  # type: ignore
-        service_name="test_workflow",
-        description="Test Workflow Service",
-        host="localhost",
-        port=8001,
+        config=WorkflowServiceConfig(
+            service_name="test_workflow",
+            description="Test Workflow Service",
+            host="localhost",
+            port=8001,
+        ),
     )
     service_task = asyncio.create_task(workflow_service.processing_loop())
 
@@ -122,10 +124,12 @@ async def test_hitl_workflow_service(
     workflow_service = WorkflowService(
         test_hitl_workflow,
         message_queue,  # type: ignore
-        service_name="test_workflow",
-        description="Test Workflow Service",
-        host="localhost",
-        port=8001,
+        config=WorkflowServiceConfig(
+            service_name="test_workflow",
+            description="Test Workflow Service",
+            host="localhost",
+            port=8001,
+        ),
     )
 
     # launch it
@@ -180,10 +184,12 @@ def test_defaults(
     workflow_service = WorkflowService(
         test_workflow,
         None,  # type: ignore
-        service_name="test_workflow",
-        description="Test Workflow Service",
-        host="localhost",
-        port=8001,
+        config=WorkflowServiceConfig(
+            service_name="test_workflow",
+            description="Test Workflow Service",
+            host="localhost",
+            port=8001,
+        ),
     )
     assert workflow_service.publisher_id.startswith("WorkflowService-")
     assert workflow_service.publish_callback is None


### PR DESCRIPTION
Enforce a single source of truth for the `WorkflowService` configuration through the `WorkflowServiceConfig` object. Base class doesn't need to be Pydantic model anymore.