### PR TITLE
refact: support absolute paths in local source manager

### DIFF
--- a/e2e_tests/apiserver/rc/deployment.yml
+++ b/e2e_tests/apiserver/rc/deployment.yml
@@ -11,5 +11,5 @@ services:
     host: localhost
     source:
       type: local
-      name: ./e2e_tests/apiserver/rc/src
+      name: src
     path: workflow:echo_workflow

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -6,7 +6,7 @@ import sys
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from shutil import rmtree
-from typing import Any
+from typing import Any, Type
 
 import httpx
 from dotenv import dotenv_values
@@ -40,9 +40,9 @@ from .deployment_config_parser import (
 )
 from .source_managers import GitSourceManager, LocalSourceManager, SourceManager
 
-SOURCE_MANAGERS: dict[SourceType, SourceManager] = {
-    SourceType.git: GitSourceManager(),
-    SourceType.local: LocalSourceManager(),
+SOURCE_MANAGERS: dict[SourceType, Type[SourceManager]] = {
+    SourceType.git: GitSourceManager,
+    SourceType.local: LocalSourceManager,
 }
 
 
@@ -228,7 +228,7 @@ class Deployment:
                 # for any source manager currently supported.
                 rmtree(str(destination))
 
-            source_manager = SOURCE_MANAGERS[source.type]
+            source_manager = SOURCE_MANAGERS[source.type](config)
             source_manager.sync(source.name, str(destination))
 
             # Install dependencies

--- a/llama_deploy/apiserver/deployment_config_parser.py
+++ b/llama_deploy/apiserver/deployment_config_parser.py
@@ -71,6 +71,7 @@ class DeploymentConfig(BaseModel):
     message_queue: MessageQueueConfig | None = Field(None, alias="message-queue")
     default_service: str | None = Field(None, alias="default-service")
     services: dict[str, Service]
+    base_path: Path = Path()
 
     @classmethod
     def from_yaml_bytes(cls, src: bytes) -> Self:
@@ -83,4 +84,4 @@ class DeploymentConfig(BaseModel):
         """Read config data from a yaml file."""
         with open(path, "r") as yaml_file:
             config = yaml.safe_load(yaml_file) or {}
-        return cls(**config)
+        return cls(**config, base_path=path.parent)

--- a/llama_deploy/apiserver/source_managers/__init__.py
+++ b/llama_deploy/apiserver/source_managers/__init__.py
@@ -1,19 +1,5 @@
-from typing import Protocol
-
+from .base import SourceManager
 from .git import GitSourceManager
 from .local import LocalSourceManager
 
-__all__ = ["GitSourceManager", "LocalSourceManager"]
-
-
-class SourceManager(Protocol):
-    """Protocol to be implemented by classes responsible for managing Deployment sources."""
-
-    def sync(
-        self, source: str, destination: str | None = None
-    ) -> None:  # pragma: no cover
-        """Fetches resources from `source` so they can be used in a deployment.
-
-        Optionally uses `destination` to store data when this makes sense for the
-        specific source type.
-        """
+__all__ = ["GitSourceManager", "LocalSourceManager", "SourceManager"]

--- a/llama_deploy/apiserver/source_managers/base.py
+++ b/llama_deploy/apiserver/source_managers/base.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+from llama_deploy.apiserver.deployment_config_parser import DeploymentConfig
+
+
+class SourceManager(ABC):
+    """Protocol to be implemented by classes responsible for managing Deployment sources."""
+
+    def __init__(self, config: DeploymentConfig) -> None:
+        self._config = config
+
+    @abstractmethod
+    def sync(
+        self, source: str, destination: str | None = None
+    ) -> None:  # pragma: no cover
+        """Fetches resources from `source` so they can be used in a deployment.
+
+        Optionally uses `destination` to store data when this makes sense for the
+        specific source type.
+        """

--- a/llama_deploy/apiserver/source_managers/git.py
+++ b/llama_deploy/apiserver/source_managers/git.py
@@ -2,8 +2,10 @@ from typing import Any
 
 from git import Repo
 
+from .base import SourceManager
 
-class GitSourceManager:
+
+class GitSourceManager(SourceManager):
     """A SourceManager specialized for sources of type `git`."""
 
     def sync(self, source: str, destination: str | None = None) -> None:

--- a/llama_deploy/apiserver/source_managers/local.py
+++ b/llama_deploy/apiserver/source_managers/local.py
@@ -1,7 +1,9 @@
 import shutil
 
+from .base import SourceManager
 
-class LocalSourceManager:
+
+class LocalSourceManager(SourceManager):
     """A SourceManager specialized for sources of type `local`."""
 
     def sync(self, source: str, destination: str | None = None) -> None:
@@ -15,7 +17,8 @@ class LocalSourceManager:
             raise ValueError("Destination cannot be empty")
 
         try:
-            shutil.copytree(source, destination, dirs_exist_ok=True)
-        except shutil.Error as e:
+            final_path = self._config.base_path / source
+            shutil.copytree(final_path, destination, dirs_exist_ok=True)
+        except Exception as e:
             msg = f"Unable to copy {source} into {destination}: {e}"
             raise ValueError(msg) from e

--- a/tests/apiserver/data/local.yaml
+++ b/tests/apiserver/data/local.yaml
@@ -1,0 +1,13 @@
+name: LocalDeploymentRelativePath
+
+control-plane: {}
+
+services:
+  test-workflow:
+    name: Test Workflow
+    port: 8002
+    host: localhost
+    source:
+      type: local
+      name: workflow
+    path: workflow:my_workflow

--- a/tests/apiserver/source_managers/test_local.py
+++ b/tests/apiserver/source_managers/test_local.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from llama_deploy.apiserver import DeploymentConfig
+from llama_deploy.apiserver.source_managers.local import LocalSourceManager
+
+
+@pytest.fixture
+def config(data_path: Path) -> DeploymentConfig:
+    return DeploymentConfig.from_yaml(data_path / "local.yaml")
+
+
+def test_dest_missing(config: DeploymentConfig) -> None:
+    sm = LocalSourceManager(config)
+    with pytest.raises(ValueError, match="Destination cannot be empty"):
+        sm.sync("source", "")
+
+
+def test_sync_error(config: DeploymentConfig) -> None:
+    sm = LocalSourceManager(config)
+    with mock.patch(
+        "llama_deploy.apiserver.source_managers.local.shutil"
+    ) as shutil_mock:
+        shutil_mock.copytree.side_effect = Exception("this was a test")
+        with pytest.raises(
+            ValueError, match="Unable to copy source into dest: this was a test"
+        ):
+            sm.sync("source", "dest")
+
+
+def test_relative_path(tmp_path: Path, data_path: Path) -> None:
+    config = DeploymentConfig.from_yaml(data_path / "local.yaml")
+    sm = LocalSourceManager(config)
+
+    sm.sync("workflow", str(tmp_path))
+    fnames = list(f.name for f in tmp_path.iterdir())
+    assert "workflow_test.py" in fnames
+    assert "__init__.py" in fnames
+
+
+def test_absolute_path(tmp_path: Path, data_path: Path) -> None:
+    config = DeploymentConfig.from_yaml(data_path / "local.yaml")
+    wf_dir = data_path / "workflow"
+    sm = LocalSourceManager(config)
+
+    sm.sync(str(wf_dir.absolute()), str(tmp_path))
+    fnames = list(f.name for f in tmp_path.iterdir())
+    assert "workflow_test.py" in fnames
+    assert "__init__.py" in fnames

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -34,7 +34,7 @@ def test_deployment_ctor(data_path: Path, mock_importlib: Any) -> None:
         sm_dict["git"] = mock.MagicMock()
         d = Deployment(config=config, root_path=Path("."))
 
-        sm_dict["git"].sync.assert_called_once()
+        sm_dict["git"].return_value.sync.assert_called_once()
         assert d.name == "TestDeployment"
         assert d.path.name == "TestDeployment"
         assert type(d._control_plane) is ControlPlaneServer


### PR DESCRIPTION
This PR introduced the concept that the path for a service with a local source is relative to the deployment file. For example, if you have a deployment file `/foo/bar/deployment.yml` containing the following:
```yaml
services:
  dummy_workflow:
    name: Dummy Workflow
    source:
      type: local
      name: src  # Relative to what?
    path: workflow:echo_workflow
```
the local source manager will look for `src` in `/foo/bar/src`. 

This change required a refactoring of the source managers: 
- managers now take a `DeploymentConfig` instance in the constructor, hence the protocol was changed into an abstract class
- the deployment config has a new field `base_path` that's automatically populated when `from_yaml` is used.