### PR TITLE
docker: add a new image flavor: `autodeploy`

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -47,5 +47,5 @@ jobs:
           LLAMA_DEPLOY_VERSION: ${{ steps.meta.outputs.version }}
         with:
           workdir: docker
-          targets: default
+          targets: all
           push: true

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -28,18 +28,28 @@ RUN pip install --upgrade pip && \
 
 FROM $dist_image AS final
 
+ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git
 
-ARG entrypoint_script
 ARG apiserver_port
+ARG rc_path
 
 EXPOSE ${apiserver_port}
 
 COPY --from=build-image /opt/venv /opt/venv
-COPY ./$entrypoint_script /opt/${entrypoint_script}
-RUN chmod +x /opt/${entrypoint_script}
+COPY ./run_apiserver.py /opt
+COPY ./run_autodeploy.py /opt
 
-ENV PATH="/opt/venv/bin:$PATH"
+# Default configuration, override with "docker run -e NAME=value"
+ENV LLAMA_DEPLOY_APISERVER_RC_PATH=${rc_path}
+ENV LLAMA_DEPLOY_APISERVER_HOST=0.0.0.0
+ENV LLAMA_DEPLOY_APISERVER_PORT=${apiserver_port}
 
-ENTRYPOINT ["python", "-m", "llama_deploy.apiserver"]
+FROM final AS base
+
+ENTRYPOINT [ "python", "/opt/run_apiserver.py" ]
+
+FROM final AS autodeploy
+
+ENTRYPOINT [ "python", "/opt/run_autodeploy.py" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,16 +6,10 @@ can be used to simplify deployments by reducing boiler plate code.
 ## Image Development
 
 Images are built with [BuildKit](https://docs.docker.com/build/buildkit/) and we use
-`bake` to orchestrate the process. You can build a specific image by running:
+`bake` to orchestrate the process. To build all the available images run:
 
 ```sh
-docker buildx bake control_plane
-```
-
-By default, all the images are built if no target is passed:
-
-```sh
-docker buildx bake
+docker buildx bake all
 ```
 
 You can override any `variable` defined in the `docker-bake.hcl` file and build custom
@@ -46,17 +40,4 @@ to ARM only by invoking `bake` like this:
 
 ```sh
 docker buildx bake control_plane --set "*.platform=linux/arm64"
-```
-
-## Docker Compose base files
-
-This folders also contains yaml code that can be included in your compose files to
-elimninate boilerplate. For example, you can deploy the core components by just
-adding this to your compose file:
-
-```yaml
-include:
-  - path: path/to/llama_deploy/docker/docker-compose-simple.yml
-
-services: ...
 ```

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -31,12 +31,17 @@ variable "APISERVER_PORT" {
 }
 
 variable "ENTRYPOINT_SCRIPT" {
-    default = "run_apiserver.sh"
+    default = "run_apiserver.py"
+}
+
+variable "RC_PATH" {
+    default = "/data"
 }
 
 target "default" {
     dockerfile = "Dockerfile.base"
     tags = ["${IMAGE_NAME}:${IMAGE_TAG_SUFFIX}"]
+    target = "base"
     args = {
         build_image = "${BUILD_IMAGE}"
         dist_image = "${DIST_IMAGE}"
@@ -46,6 +51,21 @@ target "default" {
         git_clone_options = "${GIT_CLONE_OPTIONS}"
         apiserver_port = "${APISERVER_PORT}"
         entrypoint_script = "${ENTRYPOINT_SCRIPT}"
+        rc_path = "${RC_PATH}"
     }
     platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "autodeploy" {
+    inherits = ["default"]
+    tags = ["${IMAGE_NAME}:${IMAGE_TAG_SUFFIX}-autodeploy"]
+    target = "autodeploy"
+    args = {
+        entrypoint_script = "run_autodeploy.py",
+        apiserver_port = 8080,
+    }
+}
+
+group "all" {
+  targets = ["default", "autodeploy"]
 }

--- a/docker/run_apiserver.py
+++ b/docker/run_apiserver.py
@@ -1,0 +1,11 @@
+import uvicorn
+
+from llama_deploy.apiserver import ApiserverSettings
+
+if __name__ == "__main__":
+    settings = ApiserverSettings()
+    uvicorn.run(
+        "llama_deploy.apiserver:app",
+        host=settings.host,
+        port=settings.port,
+    )

--- a/docker/run_apiserver.sh
+++ b/docker/run_apiserver.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-/opt/venv/bin/python -m llama_deploy.apiserver

--- a/docker/run_autodeploy.py
+++ b/docker/run_autodeploy.py
@@ -1,0 +1,85 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import uvicorn
+
+from llama_deploy.apiserver import ApiserverSettings
+
+CLONED_REPO_FOLDER = Path("cloned_repo")
+RC_PATH = Path("/data")
+
+
+def run_process(args: list[str], cwd: str | None = None) -> None:
+    kwargs = {
+        "args": args,
+        "capture_output": True,
+        "text": True,
+        "check": False,
+    }
+    if cwd:
+        kwargs["cwd"] = cwd
+    process = subprocess.run(**kwargs)  # type: ignore
+    if process.returncode != 0:
+        stderr = process.stderr or ""
+        raise Exception(stderr)
+
+
+def setup_repo(
+    work_dir: Path, source: str, token: str | None = None, force: bool = False
+) -> None:
+    repo_url = source
+    if token:
+        repo_url = repo_url.replace("https://", f"https://{token}@")
+
+    dest_dir = work_dir / CLONED_REPO_FOLDER
+
+    if not dest_dir.exists() or force:
+        run_process(
+            ["git", "clone", "--depth", "1", repo_url, str(dest_dir.absolute())]
+        )
+    else:
+        run_process(["git", "pull", "origin", "main"], cwd=str(dest_dir.absolute()))
+
+
+def copy_sources(work_dir: Path, deployment_file_path: Path) -> None:
+    app_folder = deployment_file_path.parent
+    for item in app_folder.iterdir():
+        if item.is_dir():
+            # For directories, use copytree with dirs_exist_ok=True
+            shutil.copytree(
+                item, f"{work_dir.absolute()}/{item.name}", dirs_exist_ok=True
+            )
+        else:
+            # For files, use copy2 to preserve metadata
+            shutil.copy2(item, str(work_dir))
+
+
+if __name__ == "__main__":
+    repo_url = os.environ.get("REPO_URL", "")
+    if not repo_url.startswith("https://"):
+        raise ValueError("Git remote must be valid and over HTTPS")
+    repo_token = os.environ.get("GITHUB_PAT")
+    work_dir = Path(os.environ.get("WORK_DIR", RC_PATH))
+    work_dir.mkdir(exist_ok=True, parents=True)
+
+    setup_repo(work_dir, repo_url, repo_token)
+
+    deployment_file_path = os.environ.get("DEPLOYMENT_FILE_PATH", "deployment.yml")
+    deployment_file_abspath = work_dir / CLONED_REPO_FOLDER / deployment_file_path
+
+    if not deployment_file_abspath.exists():
+        raise ValueError(f"File {deployment_file_abspath} does not exist")
+
+    copy_sources(work_dir, deployment_file_abspath)
+    shutil.rmtree(work_dir / CLONED_REPO_FOLDER)
+
+    # Ready to go
+    os.environ["LLAMA_DEPLOY_APISERVER_RC_PATH"] = str(work_dir)
+    settings = ApiserverSettings()
+    uvicorn.run(
+        "llama_deploy.apiserver:app",
+        host=settings.host,
+        port=settings.port,
+    )

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -109,8 +109,10 @@ class Deployment:
         # Control Plane
         tasks = await self._start_control_plane()
 
-        # Services
-        tasks.append(asyncio.create_task(self._run_services()))
+        # Services. It makes no sense for a deployment to have no services but
+        # the configuration allows it, so let's be defensive here.'
+        if self._workflow_services:
+            tasks.append(asyncio.create_task(self._run_services()))
 
         # Run allthethings
         await asyncio.gather(*tasks)

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -109,8 +109,8 @@ class Deployment:
         # Control Plane
         tasks = await self._start_control_plane()
 
-        # Services. It makes no sense for a deployment to have no services but
-        # the configuration allows it, so let's be defensive here.'
+        # Start the services. It makes no sense for a deployment to have no services but
+        # the configuration allows it, so let's be defensive here.
         if self._workflow_services:
             tasks.append(asyncio.create_task(self._run_services()))
 

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -22,6 +22,7 @@ manager = Manager(
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
     settings = ApiserverSettings()
     t = manager.serve()
+    logger.info(f"deployments folder: {manager._deployments_path}")
     logger.info(f"rc folder: {settings.rc_path}")
 
     if settings.rc_path.exists():


### PR DESCRIPTION
With this PR we add a new docker image tagged with `autodeploy` capable of loading and running a deployment from a Github repository at boot time, for example:

`docker run --rm -e REPO_URL=https://github.com/masci/test-deploy.git -e DEPLOYMENT_FILE_PATH=nested/quick_start.yml -p8080:8080 llamaindex/llama-deploy:main-autodeploy`