### PR TITLE
Pass client timeout to underlying client

### DIFF
--- a/llama_deploy/client/async_client.py
+++ b/llama_deploy/client/async_client.py
@@ -134,7 +134,7 @@ class AsyncSessionClient:
         start_time = time.time()
         while True:
             try:
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
                     async with client.stream(
                         "GET",
                         f"{self.control_plane_url}/sessions/{self.session_id}/tasks/{task_id}/result_stream",

--- a/llama_deploy/client/models/core.py
+++ b/llama_deploy/client/models/core.py
@@ -136,7 +136,7 @@ class Session(Model):
         start_time = time.time()
         while True:
             try:
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(timeout=self.client.timeout) as client:
                     async with client.stream("GET", url) as response:
                         response.raise_for_status()
                         async for line in response.aiter_lines():

--- a/llama_deploy/client/sync_client.py
+++ b/llama_deploy/client/sync_client.py
@@ -136,7 +136,7 @@ class SessionClient:
             TimeoutError: If the result is not available after max_retries.
         """
         start_time = time.time()
-        with httpx.Client() as client:
+        with httpx.Client(timeout=self.timeout) as client:
             while True:
                 try:
                     response = client.get(

--- a/tests/client/models/test_core.py
+++ b/tests/client/models/test_core.py
@@ -367,13 +367,15 @@ async def test_get_task_result_stream_timeout(client: mock.AsyncMock) -> None:
                 response=Mock404Response(),  # type: ignore
             )
 
-    with mock.patch("httpx.AsyncClient", return_value=HttpxMockClient()):
+    with mock.patch("httpx.AsyncClient", return_value=HttpxMockClient()) as mock_client:
         client.timeout = 1
         session = Session(client=client, id="test_session_id")
 
         with pytest.raises(TimeoutError):
             async for _ in session.get_task_result_stream("test_task_id"):
                 pass
+
+        mock_client.assert_called_with(timeout=1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is a PR to address https://github.com/run-llama/llama_deploy/issues/374

@masci I think you're right about the fine grained timeout configurations.  Adding that capability introduces difficulties with serialization and ease of use via environment variables and may not be worth the effort.