### PR TITLE
fix: compute URLs returned in root path

### DIFF
--- a/llama_deploy/apiserver/app.py
+++ b/llama_deploy/apiserver/app.py
@@ -3,6 +3,7 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.requests import Request
 from fastapi.responses import JSONResponse
 
 from .routers import deployments_router, status_router
@@ -28,10 +29,10 @@ app.include_router(status_router)
 
 
 @app.get("/")
-async def root() -> JSONResponse:
+async def root(request: Request) -> JSONResponse:
     return JSONResponse(
         {
-            "swagger_docs": "http://localhost:4501/docs",
-            "status": "http://localhost:4501/status",
+            "swagger_docs": f"{request.base_url}docs",
+            "status": f"{request.base_url}status",
         }
     )


### PR DESCRIPTION
The root path of the apiserver `/` returns the link to the status endpoint and the link to the OpenAPI docs endpoint. Currently they are hardcoded, meaning they don't work when user changes the host or port of the API Server. This PR computes the URL dynamically.