### PR TITLE
feat: use Prometheus to publish API Server metrics

### DIFF
--- a/docker/run_apiserver.py
+++ b/docker/run_apiserver.py
@@ -1,9 +1,14 @@
 import uvicorn
+from prometheus_client import start_http_server
 
 from llama_deploy.apiserver import ApiserverSettings
 
 if __name__ == "__main__":
     settings = ApiserverSettings()
+
+    if settings.prometheus_enabled:
+        start_http_server(settings.prometheus_port)
+
     uvicorn.run(
         "llama_deploy.apiserver:app",
         host=settings.host,

--- a/docker/run_autodeploy.py
+++ b/docker/run_autodeploy.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 
 import uvicorn
+from prometheus_client import start_http_server
 
 from llama_deploy.apiserver import ApiserverSettings
 
@@ -57,6 +58,11 @@ def copy_sources(work_dir: Path, deployment_file_path: Path) -> None:
 
 
 if __name__ == "__main__":
+    settings = ApiserverSettings()
+
+    if settings.prometheus_enabled:
+        start_http_server(settings.prometheus_port)
+
     repo_url = os.environ.get("REPO_URL", "")
     if not repo_url.startswith("https://"):
         raise ValueError("Git remote must be valid and over HTTPS")
@@ -77,7 +83,6 @@ if __name__ == "__main__":
 
     # Ready to go
     os.environ["LLAMA_DEPLOY_APISERVER_RC_PATH"] = str(work_dir)
-    settings = ApiserverSettings()
     uvicorn.run(
         "llama_deploy.apiserver:app",
         host=settings.host,

--- a/llama_deploy/apiserver/__main__.py
+++ b/llama_deploy/apiserver/__main__.py
@@ -1,9 +1,14 @@
 import uvicorn
+from prometheus_client import start_http_server
 
 from .settings import ApiserverSettings
 
 if __name__ == "__main__":
     settings = ApiserverSettings()
+
+    if settings.prometheus_enabled:
+        start_http_server(settings.prometheus_port)
+
     uvicorn.run(
         "llama_deploy.apiserver:app",
         host=settings.host,

--- a/llama_deploy/apiserver/settings.py
+++ b/llama_deploy/apiserver/settings.py
@@ -27,6 +27,14 @@ class ApiserverSettings(BaseSettings):
         default=False,
         description="Use TLS (HTTPS) to communicate with the API Server",
     )
+    prometheus_enabled: bool = Field(
+        default=True,
+        description="Whether to enable the Prometheus metrics exporter along with the API Server",
+    )
+    prometheus_port: int = Field(
+        default=9000,
+        description="The port where to serve Prometheus metrics",
+    )
 
     @property
     def url(self) -> str:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1520,6 +1520,20 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "prometheus-client"
+version = "0.21.1"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "prometheus_client-0.21.1-py3-none-any.whl", hash = "sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301"},
+    {file = "prometheus_client-0.21.1.tar.gz", hash = "sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb"},
+]
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "propcache"
 version = "0.2.1"
 description = "Accelerated property cache"
@@ -3111,4 +3125,4 @@ solace = ["solace-pubsubplus"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "51bc5b5556f3cbc9b13ec3b3cdb7bd98ecb7e597a7fe79de33e7c78c2c831488"
+content-hash = "55afb29ab600f1874578cc0f7929a98cc8110da6e3e9107b443e5fa3cc1b8e1c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ python-multipart = "^0.0.18"
 typing_extensions = "^4.0.0"
 asgiref = "^3.8.1"
 python-dotenv = "^1.0.1"
+prometheus-client = "^0.21.1"
 
 [tool.poetry.extras]
 kafka = ["aiokafka", "kafka-python-ng"]


### PR DESCRIPTION
In preparation of providing proper observability for the whole LlamaDeploy system, this PR introduces the use of Prometheus to collect and expose metrics. The Prometheus server is enable by default but can be disabled setting the environment variable `LLAMA_DEPLOY_APISERVER_PROMETHEUS_ENABLED=false`.