### PR TITLE
feat: track deployment and service status with Prometheus

### DIFF
--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from .deployment import Manager
 from .deployment_config_parser import DeploymentConfig
 from .settings import ApiserverSettings
+from .stats import apiserver_state
 
 logger = logging.getLogger("uvicorn.info")
 manager = Manager(
@@ -20,6 +21,7 @@ manager = Manager(
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
+    apiserver_state.state("starting")
     settings = ApiserverSettings()
     t = manager.serve()
     logger.info(f"deployments folder: {manager._deployments_path}")
@@ -38,9 +40,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
             except Exception as e:
                 logger.error(f"Failed to deploy {yaml_file}: {str(e)}")
 
+    apiserver_state.state("running")
     yield
 
     t.close()
     # Clean up deployments folder
     if os.path.exists(manager._deployments_path.resolve()):
         shutil.rmtree(manager._deployments_path.resolve())
+    apiserver_state.state("stopped")

--- a/llama_deploy/apiserver/stats.py
+++ b/llama_deploy/apiserver/stats.py
@@ -1,0 +1,36 @@
+from prometheus_client import Enum
+
+apiserver_state = Enum(
+    "apiserver_state",
+    "Current state of the API server",
+    states=[
+        "starting",
+        "running",
+        "stopped",
+    ],
+)
+
+deployment_state = Enum(
+    "deployment_state",
+    "Current state of a deployment",
+    ["deployment_name"],
+    states=[
+        "loading_services",
+        "ready",
+        "starting_services",
+        "running",
+        "stopped",
+    ],
+)
+
+service_state = Enum(
+    "deployment_state",
+    "Current state of a service attached to a deployment",
+    ["deployment_name", "service_name"],
+    states=[
+        "loading",
+        "syncing",
+        "installing",
+        "ready",
+    ],
+)

--- a/llama_deploy/apiserver/stats.py
+++ b/llama_deploy/apiserver/stats.py
@@ -24,7 +24,7 @@ deployment_state = Enum(
 )
 
 service_state = Enum(
-    "deployment_state",
+    "service_state",
     "Current state of a service attached to a deployment",
     ["deployment_name", "service_name"],
     states=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ omit = [
   "tests/*",
   # deprecated modules
   "llama_deploy/client/async_client.py",
-  "llama_deploy/client/sync_client.py"
+  "llama_deploy/client/sync_client.py",
+  # observability definitions
+  "llama_deploy/apiserver/stats.py"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
After requesting the API Server to create a deployment, some time can pass in order to fetch the code, install dependencies and setting up all the LlamaDeploy components that are needed. 

With this PR we track in Prometheus the intermediate states for the API Server itself, a deployment and its services.
We also need better logging but I won't add it here to ease the review.

Resulting metrics:
```
# HELP deployment_state Current state of a deployment
# TYPE deployment_state gauge
deployment_state{deployment_name="QuickStart",deployment_state="loading_services"} 0.0
deployment_state{deployment_name="QuickStart",deployment_state="ready"} 0.0
deployment_state{deployment_name="QuickStart",deployment_state="starting_services"} 1.0
deployment_state{deployment_name="QuickStart",deployment_state="running"} 0.0
deployment_state{deployment_name="QuickStart",deployment_state="stopped"} 0.0
# HELP service_state Current state of a service attached to a deployment
# TYPE service_state gauge
service_state{deployment_name="QuickStart",service_name="dummy_workflow",service_state="loading"} 0.0
service_state{deployment_name="QuickStart",service_name="dummy_workflow",service_state="syncing"} 0.0
service_state{deployment_name="QuickStart",service_name="dummy_workflow",service_state="installing"} 0.0
service_state{deployment_name="QuickStart",service_name="dummy_workflow",service_state="ready"} 1.0
```
(when a state goes to 1.0 the others switch to 0.0)