### PR TITLE
fix: raise an error when task.session_id doesn't match session_id

### DIFF
--- a/tests/control_plane/conftest.py
+++ b/tests/control_plane/conftest.py
@@ -1,0 +1,25 @@
+from typing import Any
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from llama_deploy.control_plane.server import ControlPlaneConfig, ControlPlaneServer
+
+
+@pytest.fixture
+def kvstore() -> Any:
+    with mock.patch(
+        "llama_deploy.control_plane.server.SimpleKVStore"
+    ) as mocked_kvstore:
+        mock_instance = mock.AsyncMock()
+        mocked_kvstore.return_value = mock_instance
+        yield mock_instance
+
+
+@pytest.fixture
+def http_client(kvstore: Any) -> TestClient:
+    server = ControlPlaneServer(
+        message_queue=mock.AsyncMock(), config=ControlPlaneConfig(cors_origins=["*"])
+    )
+    return TestClient(server.app)

--- a/tests/control_plane/test_config.py
+++ b/tests/control_plane/test_config.py
@@ -9,6 +9,8 @@ from llama_deploy.control_plane.config import parse_state_store_uri
 def test_config_url() -> None:
     cfg = ControlPlaneConfig(host="localhost", port=4242)
     assert cfg.url == "http://localhost:4242"
+    cfg = ControlPlaneConfig(host="localhost", port=4242, use_tls=True)
+    assert cfg.url == "https://localhost:4242"
 
 
 def test_parse_state_store_uri_malformed() -> None:

--- a/tests/control_plane/test_server.py
+++ b/tests/control_plane/test_server.py
@@ -85,7 +85,7 @@ async def test_process_message() -> None:
 
     with pytest.raises(
         ValueError,
-        match="Action ActionTypes.REQUEST_FOR_HELP not supported by control plane",
+        match=r"Action .* not supported by control plane",
     ):
         msg = QueueMessage(action=ActionTypes.REQUEST_FOR_HELP, data={"foo": "bar"})
         await server.process_message(msg)

--- a/tests/control_plane/test_server.py
+++ b/tests/control_plane/test_server.py
@@ -1,9 +1,14 @@
+from typing import Any
 from unittest import mock
 
 import pytest
+from fastapi.testclient import TestClient
 
 from llama_deploy.control_plane import ControlPlaneConfig, ControlPlaneServer
 from llama_deploy.message_queues import SimpleMessageQueueServer
+from llama_deploy.messages.base import QueueMessage
+from llama_deploy.types import TaskDefinition
+from llama_deploy.types.core import ActionTypes
 
 
 def test_control_plane_init() -> None:
@@ -40,3 +45,78 @@ def test_control_plane_init_state_store() -> None:
             config=ControlPlaneConfig(state_store_uri="test/uri"),
         )
         mocked_parse.assert_called_with("test/uri")
+
+
+@pytest.mark.asyncio
+async def test_process_message() -> None:
+    server = ControlPlaneServer(message_queue=mock.AsyncMock())
+    server.create_session = mock.AsyncMock()  # type: ignore
+    server.add_task_to_session = mock.AsyncMock()  # type: ignore
+    server.handle_service_completion = mock.AsyncMock()  # type: ignore
+    server.add_stream_to_session = mock.AsyncMock()  # type: ignore
+
+    with pytest.raises(ValueError, match="Invalid field 'data' in QueueMessage: {}"):
+        msg = QueueMessage(action=ActionTypes.NEW_TASK)
+        await server.process_message(msg)
+
+    msg = QueueMessage(action=ActionTypes.NEW_TASK, data={"input": "foo"})
+    await server.process_message(msg)
+    server.create_session.assert_awaited_once()
+    server.add_task_to_session.assert_awaited_once()
+
+    msg = QueueMessage(
+        action=ActionTypes.COMPLETED_TASK,
+        data={"task_id": "test-task", "history": [], "result": ""},
+    )
+    await server.process_message(msg)
+    server.handle_service_completion.assert_awaited_once()
+
+    msg = QueueMessage(
+        action=ActionTypes.TASK_STREAM,
+        data={
+            "task_id": "test-task",
+            "session_id": "test-session",
+            "data": {},
+            "index": 0,
+        },
+    )
+    await server.process_message(msg)
+    server.add_stream_to_session.assert_awaited_once()
+
+    with pytest.raises(
+        ValueError,
+        match="Action ActionTypes.REQUEST_FOR_HELP not supported by control plane",
+    ):
+        msg = QueueMessage(action=ActionTypes.REQUEST_FOR_HELP, data={"foo": "bar"})
+        await server.process_message(msg)
+
+
+def test_add_task_to_session_not_found(http_client: TestClient, kvstore: Any) -> None:
+    kvstore.aget.return_value = None
+    td = TaskDefinition(input="")
+    response = http_client.post("/sessions/test_session_id/tasks", json=td.model_dump())
+    assert response.status_code == 404
+
+
+def test_add_task_to_session_populate_session_id(
+    http_client: TestClient, kvstore: Any
+) -> None:
+    kvstore.aget.return_value = {}
+    td = TaskDefinition(input="", service_id="test-id")
+    response = http_client.post("/sessions/test_session_id/tasks", json=td.model_dump())
+    assert response.status_code == 200
+    # The second call to aput() contains the updated task definition
+    assert kvstore.aput.await_args_list[1].args[1]["session_id"] == "test_session_id"
+
+
+def test_add_task_to_session_session_id_mismatch(
+    http_client: TestClient, kvstore: Any
+) -> None:
+    kvstore.aget.return_value = {}
+    td = TaskDefinition(input="", service_id="test-id", session_id="wrong-id")
+    response = http_client.post("/sessions/test-session-id/tasks", json=td.model_dump())
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "Wrong task definition: task.session_id is wrong-id but should be test-session-id"
+    )


### PR DESCRIPTION
Related to #464 

- Make `add_task_to_session` return an error when the request is invalid
- Make `process_message` more robust
- Add a bunch of unit tests, some were low-hanging fruits unrelated to this PR