### PR TITLE
feat: proxy Prometheus metrics endpoint through API Server

### DIFF
--- a/llama_deploy/apiserver/routers/status.py
+++ b/llama_deploy/apiserver/routers/status.py
@@ -36,7 +36,7 @@ async def metrics() -> PlainTextResponse:
 
     try:
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://localhost:{settings.prometheus_port}/")
+            response = await client.get(f"http://127.0.0.1:{settings.prometheus_port}/")
             return PlainTextResponse(content=response.text)
     except httpx.RequestError as exc:
         raise HTTPException(status_code=500, detail=str(exc))

--- a/llama_deploy/apiserver/routers/status.py
+++ b/llama_deploy/apiserver/routers/status.py
@@ -1,6 +1,10 @@
+import httpx
 from fastapi import APIRouter
+from fastapi.exceptions import HTTPException
+from fastapi.responses import PlainTextResponse
 
 from llama_deploy.apiserver.server import manager
+from llama_deploy.apiserver.settings import ApiserverSettings
 from llama_deploy.types.apiserver import Status, StatusEnum
 
 status_router = APIRouter(
@@ -16,3 +20,23 @@ async def status() -> Status:
         deployments=list(manager._deployments.keys()),
         status_message="",
     )
+
+
+@status_router.get("/metrics")
+async def metrics() -> PlainTextResponse:
+    """Proxies the Prometheus metrics endpoint through the API Server.
+
+    This endpoint is mostly used in serverless environments where the LlamaDeploy
+    container cannot expose more than one port (e.g. Knative, Google Cloud Run).
+    If Prometheus is not enabled, this endpoint returns an empty HTTP-204 response.
+    """
+    settings = ApiserverSettings()
+    if not settings.prometheus_enabled:
+        return PlainTextResponse(status_code=204)
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://localhost:{settings.prometheus_port}/")
+            return PlainTextResponse(content=response.text)
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/tests/apiserver/routers/test_status.py
+++ b/tests/apiserver/routers/test_status.py
@@ -1,3 +1,7 @@
+from typing import Any
+from unittest import mock
+
+import httpx
 from fastapi.testclient import TestClient
 
 
@@ -10,3 +14,30 @@ def test_read_main(http_client: TestClient) -> None:
         "status": "Healthy",
         "status_message": "",
     }
+
+
+def test_prom_proxy_off(http_client: TestClient, monkeypatch: Any) -> None:
+    monkeypatch.setenv("LLAMA_DEPLOY_APISERVER_PROMETHEUS_ENABLED", "false")
+    response = http_client.get("/status/metrics/")
+    assert response.status_code == 204
+    assert response.text == ""
+
+
+def test_prom_proxy(http_client: TestClient) -> None:
+    mock_metrics_response = 'metric1{label="value"} 1.0\nmetric2{label="value"} 2.0'
+    mock_response = httpx.Response(200, text=mock_metrics_response)
+
+    with mock.patch("httpx.AsyncClient.get", return_value=mock_response):
+        response = http_client.get("/status/metrics")
+        assert response.status_code == 200
+        assert response.text == mock_metrics_response
+
+
+def test_prom_proxy_failure(http_client: TestClient) -> None:
+    # Mock the HTTP client to raise an exception
+    with mock.patch(
+        "httpx.AsyncClient.get", side_effect=httpx.RequestError("Connection failed")
+    ):
+        response = http_client.get("/status/metrics")
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Connection failed"


### PR DESCRIPTION
In certain serverless environments like Knative and Cloud Run, it's not possible to expose more than one port from the LlamaDeploy container. In case users still want to scrape metrics, we proxy the Prometheus metrics endpoint through the `/status/metrics` endpoint of the API Server.