### PR TITLE
fix: race condition in `deployment_state` metric updates

### DIFF
--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -123,6 +123,7 @@ class Deployment:
 
         # Start the services. It makes no sense for a deployment to have no services but
         # the configuration allows it, so let's be defensive here.
+        deployment_state.labels(self._name).state("starting_services")
         if self._workflow_services:
             tasks.append(asyncio.create_task(self._run_services()))
 
@@ -177,7 +178,6 @@ class Deployment:
         if they are all cancelled. This is to support the reload process
         (see reload() for more details).
         """
-        deployment_state.labels(self._name).state("starting_services")
         while self._running:
             self._service_tasks = []
             # If this is a reload, self._workflow_services contains the updated configurations


### PR DESCRIPTION
Due to the asynchronous nature of the`start()` method, the metric `deployment_state` running state could be overwritten with `starting_services` at a later time. This was very consistent in containers, where low resources highlighted the problem causing the metric to report an incorrect value.

Note that technically a better fix would have been adding a mutex to make sure the state is always 100% accurate, but I preferred to go with this fix because metric fidelity is good enough and the code is much simpler and easy to read.