### PR TITLE
docs: improve Python SDK documentation

### DIFF
--- a/docs/docs/api_reference/llama_deploy/python_sdk.md
+++ b/docs/docs/api_reference/llama_deploy/python_sdk.md
@@ -1,5 +1,16 @@
 # Python SDK
 
-## `client`
+## Client
 
-::: llama_deploy.client
+::: llama_deploy.client.Client
+    options:
+      show_bases: false
+
+
+## API Server functionalities
+
+::: llama_deploy.client.models.apiserver
+
+## Control Plane functionalities
+
+::: llama_deploy.client.models.core

--- a/docs/docs/api_reference/llama_deploy/types.md
+++ b/docs/docs/api_reference/llama_deploy/types.md
@@ -1,8 +1,3 @@
 # `types`
 
 ::: llama_deploy.types
-    options:
-        members:
-        - TaskDefinition
-        - TaskResult
-        - TaskStream

--- a/docs/docs/module_guides/llama_deploy/40_python_sdk.md
+++ b/docs/docs/module_guides/llama_deploy/40_python_sdk.md
@@ -45,13 +45,21 @@ async def check_status():
 The client provides access to two main components:
 
 - `apiserver`: Interact with the [API server](./20_core_components.md#api-server)
-- `core`: Access [core functionalities](./20_core_components.md#control-plane) like the Control Plane.
+- `core`: Access [Control Plane](./20_core_components.md#control-plane) functionalities.
 
 Each component exposes specific methods for managing and interacting with the deployed system.
 
-> [!NOTE]
-> For a complete list of available methods and detailed API reference, see the
-> [API Reference section](../../api_reference/llama_deploy/python_sdk.md).
+> [!IMPORTANT]
+> To use the `apiserver` functionalities, the API Server must be up and its URL
+> (by default `http://localhost:4501`) reachable by the host executing the client code.
+
+> [!IMPORTANT]
+> To use the `core` functionalities, the Control Plane must be up and its URL
+> (by default `http://localhost:8000`) reachable by the host executing the client code.
+
+
+For a complete list of available methods and detailed API reference, see the
+[API Reference section](../../api_reference/llama_deploy/python_sdk.md).
 
 ## Usage Examples
 

--- a/llama_deploy/client/client.py
+++ b/llama_deploy/client/client.py
@@ -39,12 +39,12 @@ class Client(_BaseClient):
 
     @property
     def apiserver(self) -> ApiServer:
-        """Returns the ApiServer model."""
+        """Access the API Server functionalities."""
         return ApiServer(client=self, id="apiserver")
 
     @property
     def core(self) -> Core:
-        """Returns the Core model."""
+        """Access the Control Plane functionalities."""
         return Core(client=self, id="core")
 
 

--- a/llama_deploy/client/models/apiserver.py
+++ b/llama_deploy/client/models/apiserver.py
@@ -1,3 +1,11 @@
+"""Client functionalities to operate on the API Server.
+
+This module allows the client to use all the functionalities
+from the LlamaDeploy API Server. For this to work, the API
+Server must be up and its URL (by default `http://localhost:4501`)
+reachable by the host executing the client code.
+"""
+
 import asyncio
 import json
 from typing import Any, AsyncGenerator, TextIO
@@ -5,6 +13,7 @@ from typing import Any, AsyncGenerator, TextIO
 import httpx
 from llama_index.core.workflow.context_serializers import JsonSerializer
 from llama_index.core.workflow.events import Event
+from pydantic import Field
 
 from llama_deploy.types.apiserver import Status, StatusEnum
 from llama_deploy.types.core import (
@@ -20,7 +29,9 @@ from .model import Collection, Model
 class SessionCollection(Collection):
     """A model representing a collection of session for a given deployment."""
 
-    deployment_id: str
+    deployment_id: str = Field(
+        description="The ID of the deployment containing the sessions."
+    )
 
     async def delete(self, session_id: str) -> None:
         """Deletes the session with the provided `session_id`.
@@ -42,7 +53,7 @@ class SessionCollection(Collection):
         )
 
     async def create(self) -> SessionDefinition:
-        """"""
+        """Create a new session."""
         create_url = f"{self.client.api_server_url}/deployments/{self.deployment_id}/sessions/create"
 
         r = await self.client.request(
@@ -72,8 +83,10 @@ class SessionCollection(Collection):
 class Task(Model):
     """A model representing a task belonging to a given session in the given deployment."""
 
-    deployment_id: str
-    session_id: str
+    deployment_id: str = Field(
+        description="The ID of the deployment this task belongs to."
+    )
+    session_id: str = Field(description="The ID of the session this task belongs to.")
 
     async def results(self) -> TaskResult:
         """Returns the result of a given task."""
@@ -133,7 +146,9 @@ class Task(Model):
 class TaskCollection(Collection):
     """A model representing a collection of tasks for a given deployment."""
 
-    deployment_id: str
+    deployment_id: str = Field(
+        description="The ID of the deployment these tasks belong to."
+    )
 
     async def run(self, task: TaskDefinition) -> Any:
         """Runs a task and returns the results once it's done.
@@ -267,6 +282,7 @@ class DeploymentCollection(Collection):
         return model_class(client=self.client, id=id)
 
     async def list(self) -> list[Deployment]:
+        """Return a list of Deployment instances for this collection."""
         deployments_url = f"{self.client.api_server_url}/deployments/"
         r = await self.client.request("GET", deployments_url)
         model_class = self._prepare(Deployment)

--- a/llama_deploy/client/models/core.py
+++ b/llama_deploy/client/models/core.py
@@ -1,3 +1,11 @@
+"""Client functionalities to operate on the Control Plane.
+
+This module allows the client to use all the functionalities
+from the Control Plane. For this to work, the Control Plane
+must be up and its URL (by default `http://localhost:8000`)
+reachable by the host executing the client code.
+"""
+
 import asyncio
 import json
 import time
@@ -18,6 +26,8 @@ from .model import Collection, Model
 
 
 class Session(Model):
+    """A model representing a Session."""
+
     async def run(self, service_name: str, **run_kwargs: Any) -> str:
         """Implements the workflow-based run API for a session."""
         task_input = json.dumps(run_kwargs)
@@ -48,7 +58,7 @@ class Session(Model):
         """Create a new task in this session.
 
         Args:
-            task_def (Union[str, TaskDefinition]): The task definition or input string.
+            task_def (TaskDefinition): The task definition.
 
         Returns:
             str: The ID of the created task.
@@ -96,7 +106,9 @@ class Session(Model):
         """Send event to a Workflow service.
 
         Args:
-            event (Event): The event to be submitted to the workflow.
+            service_name (str): The name of the service running the target Task.
+            task_id (str): The ID of the task running the workflow receiving the event.
+            ev (Event): The event to be sent to the workflow task.
 
         Returns:
             None
@@ -113,7 +125,8 @@ class Session(Model):
         """Send event to a Workflow service.
 
         Args:
-            event (Event): The event to be submitted to the workflow.
+            task_id (str): The ID of the task running the workflow receiving the event.
+            ev_def (EventDefinition): The event definition describing the Event to send.
 
         Returns:
             None
@@ -158,6 +171,8 @@ class Session(Model):
 
 
 class SessionCollection(Collection):
+    """A model representing a collection of sessions."""
+
     async def list(self) -> list[Session]:  # type: ignore
         """Returns a list of all the sessions in the collection."""
         sessions_url = f"{self.client.control_plane_url}/sessions"
@@ -188,7 +203,7 @@ class SessionCollection(Collection):
         """Gets a session by ID.
 
         Args:
-            session_id: The ID of the session to get.
+            id (str): The ID of the session to get.
 
         Returns:
             Session: A Session object representing the specified session.
@@ -230,6 +245,8 @@ class SessionCollection(Collection):
 
 
 class Service(Model):
+    """A model representing a Service."""
+
     pass
 
 


### PR DESCRIPTION
Clarify that for `client.core` to work, the Control Plane must be reachable from the client code.