### PR TITLE
fix: use a stable hash function to dump context

### DIFF
--- a/e2e_tests/core/test_services.py
+++ b/e2e_tests/core/test_services.py
@@ -1,7 +1,14 @@
+import asyncio
+import multiprocessing
+
 import pytest
 
-from llama_deploy import Client
+from llama_deploy import (
+    Client,
+)
 from llama_deploy.types.core import ServiceDefinition
+
+from .conftest import run_async_workflow
 
 
 def test_services(workflow):
@@ -33,3 +40,46 @@ async def test_services_async(workflow):
     )
     assert new_s.id == "another_basic"
     assert len(await client.core.services.list()) == 1
+
+
+@pytest.mark.asyncio
+async def test_service_restart(core):
+    client = Client()
+
+    # create workflow service in a separate process
+    p = multiprocessing.Process(target=run_async_workflow)
+    p.start()
+    await asyncio.sleep(5)
+
+    # create session
+    session = await client.core.sessions.create()
+
+    # run
+    result = await session.run("basic")
+    assert result == "n/a_result"
+
+    # kill the service
+    p.kill()
+    p.join()
+
+    # restart the service
+    p = multiprocessing.Process(target=run_async_workflow)
+    p.start()
+    await asyncio.sleep(5)
+
+    # run again, same session
+    result = await session.run("basic")
+    assert result == "n/a_result"
+
+    # assert len(await client.core.services.list()) == 1
+    # await client.core.services.deregister("basic")
+    # assert len(await client.core.services.list()) == 0
+
+    # new_s = await client.core.services.register(
+    #     ServiceDefinition(service_name="another_basic", description="none")
+    # )
+    # assert new_s.id == "another_basic"
+    # assert len(await client.core.services.list()) == 1
+
+    p.kill()
+    p.join()

--- a/e2e_tests/core/workflow.py
+++ b/e2e_tests/core/workflow.py
@@ -4,8 +4,5 @@ from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, 
 class BasicWorkflow(Workflow):
     @step()
     async def run_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
-        arg1 = ev.get("arg1")
-        if not arg1:
-            raise ValueError("arg1 is required.")
-
+        arg1 = ev.get("arg1", "n/a")
         return StopEvent(result=str(arg1) + "_result")


### PR DESCRIPTION
Fixes #477 

Instead of using the builtin `hash()` function that's not stable across different Python sessions (see [`https://docs.python.org/3/reference/datamodel.html#object.__hash__`](https://docs.python.org/3/reference/datamodel.html#object.__hash__)), we use `sha256`. This should guarantee the context hash remains valid across process restarts.