### PR TITLE
fix: create path to config dir if does not exist

### DIFF
--- a/llama_deploy/cli/internal/config.py
+++ b/llama_deploy/cli/internal/config.py
@@ -43,6 +43,8 @@ def load_config(path: Path | None = None) -> Config:
     if path is None:
         path = _default_config_path()
         if not path.exists():
+            # Create the config folder if doesn't exist
+            path.parent.mkdir(parents=True, exist_ok=True)
             # Use default
             config = Config(
                 current_profile=DEFAULT_PROFILE_NAME,

--- a/tests/cli/internal/test_config.py
+++ b/tests/cli/internal/test_config.py
@@ -36,3 +36,11 @@ def test_config_write(tmp_path: Path) -> None:
     )
     config.write()
     assert config_path.exists()
+
+
+def test_config_dir_doesnt_exist(tmp_path: Path) -> None:
+    with mock.patch("llama_deploy.cli.internal.utils.user_config_dir") as mock_dir:
+        mock_dir.return_value = tmp_path / "config" / "folder"
+        config = load_config(path=None)
+        assert len(config.profiles) == 1
+        assert "default" in config.profiles


### PR DESCRIPTION
The config path returned by `platformdirs` might not exist (the most likely scenario in docker containers), make sure we create the full path to the default config file when the CLI runs for the first time.