### PR TITLE
Add support for exclusive consumer mode for Redis Message Queue

### DIFF
--- a/examples/redis_message_queue/README.md
+++ b/examples/redis_message_queue/README.md
@@ -75,3 +75,6 @@ Current balance: 3.0
 $ lamactl run --deployment RedisMessageQueue --arg amount 3 -i <YOUR_SESSION_ID>
 Current balance: 3.5
 ```
+
+_Note_: If you have multiple replicas of the workflow and control plane and only want one replica to process messages,
+set `REDIS_EXCLUSIVE_MODE` to true.

--- a/llama_deploy/message_queues/redis.py
+++ b/llama_deploy/message_queues/redis.py
@@ -113,7 +113,7 @@ class RedisMessageQueue(AbstractMessageQueue):
 
                         # Deduplication check
                         if self._config.exclusive_mode:
-                            new_message = await self._redis.sadd(
+                            new_message = await self._redis.sadd(  # type: ignore
                                 processed_message_key, queue_message.id_
                             )
                             if not new_message:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ omit = [
 
 [tool.poetry]
 name = "llama-deploy"
-version = "0.7.1"
+version = "0.7.2"
 description = ""
 authors = [
   "Logan Markewich <logan.markewich@live.com>",


### PR DESCRIPTION
When using replicas for the workflow and the control plane with redis message queue, all the consumers consume and process the message. Adding support to enable exclusive consumer mode so that only one message consumer consumes and processes the message.