### PR TITLE
fix: use a global settings instance

### DIFF
--- a/docker/run_autodeploy.py
+++ b/docker/run_autodeploy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import uvicorn
 from prometheus_client import start_http_server
 
-from llama_deploy.apiserver import ApiserverSettings
+from llama_deploy.apiserver import settings
 
 CLONED_REPO_FOLDER = Path("cloned_repo")
 RC_PATH = Path("/data")
@@ -58,8 +58,6 @@ def copy_sources(work_dir: Path, deployment_file_path: Path) -> None:
 
 
 if __name__ == "__main__":
-    settings = ApiserverSettings()
-
     if settings.prometheus_enabled:
         start_http_server(settings.prometheus_port)
 

--- a/e2e_tests/apiserver/test_autodeploy.py
+++ b/e2e_tests/apiserver/test_autodeploy.py
@@ -1,11 +1,10 @@
 import pytest
 
-from llama_deploy.apiserver.settings import ApiserverSettings
+from llama_deploy.apiserver.settings import settings
 
 
 @pytest.mark.asyncio
 async def test_autodeploy(client, apiserver_with_rc):
-    settings = ApiserverSettings()
     assert str(settings.rc_path).endswith("llama_deploy/e2e_tests/apiserver/rc")
 
     status = await client.apiserver.status()

--- a/e2e_tests/apiserver/test_autodeploy.py
+++ b/e2e_tests/apiserver/test_autodeploy.py
@@ -1,11 +1,7 @@
 import pytest
 
-from llama_deploy.apiserver.settings import settings
-
 
 @pytest.mark.asyncio
 async def test_autodeploy(client, apiserver_with_rc):
-    assert str(settings.rc_path).endswith("llama_deploy/e2e_tests/apiserver/rc")
-
     status = await client.apiserver.status()
     assert "AutoDeployed" in status.deployments

--- a/llama_deploy/apiserver/__init__.py
+++ b/llama_deploy/apiserver/__init__.py
@@ -1,9 +1,9 @@
 from .app import app
 from .deployment_config_parser import DeploymentConfig
-from .settings import ApiserverSettings
+from .settings import settings
 
 __all__ = [
     "app",
-    "ApiserverSettings",
+    "settings",
     "DeploymentConfig",
 ]

--- a/llama_deploy/apiserver/__main__.py
+++ b/llama_deploy/apiserver/__main__.py
@@ -1,11 +1,9 @@
 import uvicorn
 from prometheus_client import start_http_server
 
-from .settings import ApiserverSettings
+from .settings import settings
 
 if __name__ == "__main__":
-    settings = ApiserverSettings()
-
     if settings.prometheus_enabled:
         start_http_server(settings.prometheus_port)
 

--- a/llama_deploy/apiserver/routers/status.py
+++ b/llama_deploy/apiserver/routers/status.py
@@ -4,7 +4,7 @@ from fastapi.exceptions import HTTPException
 from fastapi.responses import PlainTextResponse
 
 from llama_deploy.apiserver.server import manager
-from llama_deploy.apiserver.settings import ApiserverSettings
+from llama_deploy.apiserver.settings import settings
 from llama_deploy.types.apiserver import Status, StatusEnum
 
 status_router = APIRouter(
@@ -30,7 +30,6 @@ async def metrics() -> PlainTextResponse:
     container cannot expose more than one port (e.g. Knative, Google Cloud Run).
     If Prometheus is not enabled, this endpoint returns an empty HTTP-204 response.
     """
-    settings = ApiserverSettings()
     if not settings.prometheus_enabled:
         return PlainTextResponse(status_code=204)
 

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 
 from .deployment import Manager
 from .deployment_config_parser import DeploymentConfig
-from .settings import ApiserverSettings
+from .settings import settings
 from .stats import apiserver_state
 
 logger = logging.getLogger("uvicorn.info")
@@ -22,7 +22,6 @@ manager = Manager(
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
     apiserver_state.state("starting")
-    settings = ApiserverSettings()
     t = manager.serve()
     logger.info(f"deployments folder: {manager._deployments_path}")
     logger.info(f"rc folder: {settings.rc_path}")

--- a/llama_deploy/apiserver/settings.py
+++ b/llama_deploy/apiserver/settings.py
@@ -42,3 +42,6 @@ class ApiserverSettings(BaseSettings):
         if self.port == 80:
             return f"{protocol}{self.host}"
         return f"{protocol}{self.host}:{self.port}"
+
+
+settings = ApiserverSettings()

--- a/llama_deploy/cli/serve.py
+++ b/llama_deploy/cli/serve.py
@@ -1,9 +1,14 @@
+import click
 import uvicorn
 from prometheus_client import start_http_server
 
 from llama_deploy.apiserver import settings
 
-if __name__ == "__main__":
+
+@click.command()
+@click.option("--skip-sync", is_flag=True)
+def serve(skip_sync: bool) -> None:
+    """Run the API Server in the foreground."""
     if settings.prometheus_enabled:
         start_http_server(settings.prometheus_port)
 

--- a/tests/apiserver/routers/test_status.py
+++ b/tests/apiserver/routers/test_status.py
@@ -4,6 +4,8 @@ from unittest import mock
 import httpx
 from fastapi.testclient import TestClient
 
+from llama_deploy.apiserver import settings
+
 
 def test_read_main(http_client: TestClient) -> None:
     response = http_client.get("/status")
@@ -17,7 +19,7 @@ def test_read_main(http_client: TestClient) -> None:
 
 
 def test_prom_proxy_off(http_client: TestClient, monkeypatch: Any) -> None:
-    monkeypatch.setenv("LLAMA_DEPLOY_APISERVER_PROMETHEUS_ENABLED", "false")
+    monkeypatch.setattr(settings, "prometheus_enabled", False)
     response = http_client.get("/status/metrics/")
     assert response.status_code == 204
     assert response.text == ""

--- a/tests/apiserver/test_server.py
+++ b/tests/apiserver/test_server.py
@@ -5,8 +5,8 @@ from unittest import mock
 
 import pytest
 
-from llama_deploy.apiserver import ApiserverSettings
 from llama_deploy.apiserver.server import lifespan
+from llama_deploy.apiserver.settings import ApiserverSettings
 
 
 @pytest.mark.asyncio
@@ -25,9 +25,8 @@ async def test_lifespan(
     with open(config_file, "w") as f:
         f.write(source_file.read_text())
 
-    with mock.patch("llama_deploy.apiserver.server.ApiserverSettings") as settings:
+    with mock.patch("llama_deploy.apiserver.server.settings", actual_settings):
         mocked_manager._deployments_path.resolve.return_value = "."
-        settings.return_value = actual_settings
         caplog.set_level(logging.INFO)
         async with lifespan(mock.MagicMock()):
             pass

--- a/tests/apiserver/test_settings.py
+++ b/tests/apiserver/test_settings.py
@@ -1,4 +1,4 @@
-from llama_deploy.apiserver import ApiserverSettings
+from llama_deploy.apiserver.settings import ApiserverSettings
 
 
 def test_settings_url() -> None:


### PR DESCRIPTION
Use a Pydantic settings singleton instance to avoid re-parsing environment variables at each usage