### PR TITLE
feat: add `llamactl serve` command for local development

### DIFF
--- a/e2e_tests/apiserver/deployments/deployment_env_local.yml
+++ b/e2e_tests/apiserver/deployments/deployment_env_local.yml
@@ -12,8 +12,8 @@ services:
       type: local
       name: ./e2e_tests/apiserver/deployments/src
     env:
-      VAR_1: x  # this gets overwritten because VAR_1 also exists in the provided .env
+      VAR_1: x # this gets overwritten because VAR_1 also exists in the provided .env
       VAR_2: y
     env-files:
-      - .env  # relative to source path
-    path: workflow_env:workflow
+      - .env # relative to source path
+    path: ./e2e_tests/apiserver/deployments/src/workflow_env:workflow

--- a/e2e_tests/apiserver/deployments/deployment_env_local.yml
+++ b/e2e_tests/apiserver/deployments/deployment_env_local.yml
@@ -15,5 +15,5 @@ services:
       VAR_1: x # this gets overwritten because VAR_1 also exists in the provided .env
       VAR_2: y
     env-files:
-      - .env # relative to source path
+      - ./e2e_tests/apiserver/deployments/src/.env # relative to source path
     path: ./e2e_tests/apiserver/deployments/src/workflow_env:workflow

--- a/e2e_tests/apiserver/deployments/deployment_hitl.yml
+++ b/e2e_tests/apiserver/deployments/deployment_hitl.yml
@@ -11,4 +11,4 @@ services:
     source:
       type: local
       name: ./e2e_tests/apiserver/deployments/src
-    path: workflow_hitl:workflow
+    path: ./e2e_tests/apiserver/deployments/src/workflow_hitl:workflow

--- a/e2e_tests/apiserver/deployments/deployment_streaming.yml
+++ b/e2e_tests/apiserver/deployments/deployment_streaming.yml
@@ -11,4 +11,4 @@ services:
     source:
       type: local
       name: ./e2e_tests/apiserver/deployments/src
-    path: workflow:streaming_workflow
+    path: ./e2e_tests/apiserver/deployments/src/workflow:streaming_workflow

--- a/e2e_tests/apiserver/rc/deployment.yml
+++ b/e2e_tests/apiserver/rc/deployment.yml
@@ -12,4 +12,4 @@ services:
     source:
       type: local
       name: src
-    path: workflow:echo_workflow
+    path: src/workflow:echo_workflow

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -293,10 +293,12 @@ class Deployment:
             self._set_environment_variables(service_config, destination)
 
             # Search for a workflow instance in the service path
-            pythonpath = (destination / source.name).resolve()
-            print(pythonpath)
+            module_path_str, workflow_name = service_config.path.split(":")
+            module_path = Path(module_path_str)
+            module_name = module_path.name
+            pythonpath = (destination / module_path.parent).resolve()
+            print(pythonpath, module_name)
             sys.path.append(str(pythonpath))
-            module_name, workflow_name = Path(service_config.path).name.split(":")
             module = importlib.import_module(module_name)
 
             workflow = getattr(module, workflow_name)

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -338,6 +338,7 @@ class Deployment:
             for env_file in service_config.env_files:
                 # use dotenv to parse env_file
                 env_file_path = root / env_file if root else Path(env_file)
+                print("env_file_path", env_file_path)
                 env_vars.update(**dotenv_values(env_file_path))
 
         for k, v in env_vars.items():

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -338,7 +338,6 @@ class Deployment:
             for env_file in service_config.env_files:
                 # use dotenv to parse env_file
                 env_file_path = root / env_file if root else Path(env_file)
-                print("env_file_path", env_file_path)
                 env_vars.update(**dotenv_values(env_file_path))
 
         for k, v in env_vars.items():

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -70,7 +70,7 @@ class Deployment:
             root_path: The path on the filesystem used to store deployment data
         """
         self._name = config.name
-        self._path = root_path / config.name
+        self._path = root_path
         self._queue_client = self._load_message_queue_client(config.message_queue)
         self._control_plane_config = config.control_plane
         self._control_plane = ControlPlaneServer(
@@ -278,7 +278,7 @@ class Deployment:
 
             # Sync the service source
             service_state.labels(self._name, service_id).state("syncing")
-            destination = (self._path / service_id).resolve()
+            destination = self._path.resolve()
             source_manager = SOURCE_MANAGERS[source.type](config)
             policy = SyncPolicy.SKIP if self._skip_sync else SyncPolicy.REPLACE
             source_manager.sync(source.name, str(destination), policy)
@@ -291,7 +291,8 @@ class Deployment:
             self._set_environment_variables(service_config, destination)
 
             # Search for a workflow instance in the service path
-            pythonpath = (destination / service_config.path).parent.resolve()
+            pythonpath = (destination / service_config.source.name).resolve()
+            print("--->", self._path)
             sys.path.append(str(pythonpath))
             module_name, workflow_name = Path(service_config.path).name.split(":")
             module = importlib.import_module(module_name)

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -4,6 +4,7 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from shutil import rmtree
@@ -413,7 +414,7 @@ class Manager:
     """
 
     def __init__(
-        self, deployments_path: Path = Path(".deployments"), max_deployments: int = 10
+        self, deployments_path: Path | None, max_deployments: int = 10
     ) -> None:
         """Creates a Manager instance.
 
@@ -422,7 +423,10 @@ class Manager:
             max_deployments: The maximum number of deployments supported by this manager.
         """
         self._deployments: dict[str, Any] = {}
-        self._deployments_path = deployments_path
+        self._deployments_path = (
+            deployments_path
+            or Path(tempfile.gettempdir()) / "llama_deploy" / "deployments"
+        )
         self._max_deployments = max_deployments
         self._pool = ThreadPool(processes=max_deployments)
         self._last_control_plane_port = 8002

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -297,7 +297,7 @@ class Deployment:
             module_path = Path(module_path_str)
             module_name = module_path.name
             pythonpath = (destination / module_path.parent).resolve()
-            print(pythonpath, module_name)
+            logger.debug("Extending PYTHONPATH to %s", pythonpath)
             sys.path.append(str(pythonpath))
             module = importlib.import_module(module_name)
 

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -292,7 +292,6 @@ class Deployment:
 
             # Search for a workflow instance in the service path
             pythonpath = (destination / service_config.source.name).resolve()
-            print("--->", self._path)
             sys.path.append(str(pythonpath))
             module_name, workflow_name = Path(service_config.path).name.split(":")
             module = importlib.import_module(module_name)

--- a/llama_deploy/apiserver/deployment_config_parser.py
+++ b/llama_deploy/apiserver/deployment_config_parser.py
@@ -75,7 +75,7 @@ class DeploymentConfig(BaseModel):
     message_queue: MessageQueueConfig | None = Field(None, alias="message-queue")
     default_service: str | None = Field(None, alias="default-service")
     services: dict[str, Service]
-    base_path: Path = Path()
+    base_path: Path | None = Field(None, alias="base-path")
     ui: UIService | None = None
 
     @classmethod
@@ -89,4 +89,7 @@ class DeploymentConfig(BaseModel):
         """Read config data from a yaml file."""
         with open(path, "r") as yaml_file:
             config = yaml.safe_load(yaml_file) or {}
-        return cls(**config, base_path=path.parent)
+            if config.get("base_path") is None:
+                config["base_path"] = path.parent
+
+        return cls(**config)

--- a/llama_deploy/apiserver/deployment_config_parser.py
+++ b/llama_deploy/apiserver/deployment_config_parser.py
@@ -89,7 +89,7 @@ class DeploymentConfig(BaseModel):
         """Read config data from a yaml file."""
         with open(path, "r") as yaml_file:
             config = yaml.safe_load(yaml_file) or {}
-            if config.get("base_path") is None:
-                config["base_path"] = path.parent
+            if config.get("base-path") is None:
+                config["base-path"] = path.parent
 
         return cls(**config)

--- a/llama_deploy/apiserver/deployment_config_parser.py
+++ b/llama_deploy/apiserver/deployment_config_parser.py
@@ -53,7 +53,7 @@ class Service(BaseModel):
     """Configuration for a single service."""
 
     name: str
-    source: ServiceSource | None = None
+    source: ServiceSource
     path: str | None = None
     host: str | None = None
     port: int | None = None

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -38,11 +38,11 @@ async def read_deployment(deployment_name: str) -> DeploymentDefinition:
 async def create_deployment(
     config_file: UploadFile = File(...),
     reload: bool = False,
-    skip_sync: bool = False,
+    local: bool = False,
 ) -> DeploymentDefinition:
     """Creates a new deployment by uploading a configuration file."""
     config = DeploymentConfig.from_yaml_bytes(await config_file.read())
-    await manager.deploy(config, reload, skip_sync)
+    await manager.deploy(config, reload, local)
 
     return DeploymentDefinition(name=config.name)
 

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -36,11 +36,13 @@ async def read_deployment(deployment_name: str) -> DeploymentDefinition:
 
 @deployments_router.post("/create")
 async def create_deployment(
-    config_file: UploadFile = File(...), reload: bool = False
+    config_file: UploadFile = File(...),
+    reload: bool = False,
+    skip_sync: bool = False,
 ) -> DeploymentDefinition:
     """Creates a new deployment by uploading a configuration file."""
     config = DeploymentConfig.from_yaml_bytes(await config_file.read())
-    await manager.deploy(config, reload)
+    await manager.deploy(config, reload, skip_sync)
 
     return DeploymentDefinition(name=config.name)
 

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -12,7 +12,6 @@ from .settings import settings
 from .stats import apiserver_state
 
 logger = logging.getLogger("uvicorn.info")
-settings = ApiserverSettings()
 manager = Manager(deployments_path=settings.deployments_path)
 
 

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -1,9 +1,7 @@
 import logging
 import os
 import shutil
-import tempfile
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import Any, AsyncGenerator
 
 from fastapi import FastAPI
@@ -14,9 +12,8 @@ from .settings import settings
 from .stats import apiserver_state
 
 logger = logging.getLogger("uvicorn.info")
-manager = Manager(
-    deployments_path=Path(tempfile.gettempdir()) / "llama_deploy" / "deployments"
-)
+settings = ApiserverSettings()
+manager = Manager(deployments_path=settings.deployments_path)
 
 
 @asynccontextmanager

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -12,14 +12,16 @@ from .settings import settings
 from .stats import apiserver_state
 
 logger = logging.getLogger("uvicorn.info")
-manager = Manager(deployments_path=settings.deployments_path)
+manager = Manager()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
     apiserver_state.state("starting")
-    t = manager.serve()
-    logger.info(f"deployments folder: {manager._deployments_path}")
+
+    t = manager.serve(deployments_path=settings.deployments_path)
+
+    logger.info(f"deployments folder: {settings.deployments_path}")
     logger.info(f"rc folder: {settings.rc_path}")
 
     if settings.rc_path.exists():
@@ -39,7 +41,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
     yield
 
     t.close()
+
     # Clean up deployments folder
-    if os.path.exists(manager._deployments_path.resolve()):
-        shutil.rmtree(manager._deployments_path.resolve())
+    if os.path.exists(manager.deployments_path.resolve()):
+        shutil.rmtree(manager.deployments_path.resolve())
     apiserver_state.state("stopped")

--- a/llama_deploy/apiserver/settings.py
+++ b/llama_deploy/apiserver/settings.py
@@ -19,9 +19,9 @@ class ApiserverSettings(BaseSettings):
         default=Path("./.llama_deploy_rc"),
         description="Path to the folder containing the deployment configs that will be loaded at startup",
     )
-    deployments_path: Path = Field(
-        default=Path("./deployments"),
-        description="Path to the folder where deployments will create their root path",
+    deployments_path: Path | None = Field(
+        default=None,
+        description="Path to the folder where deployments will create their root path, defaults to a temp dir",
     )
     use_tls: bool = Field(
         default=False,

--- a/llama_deploy/apiserver/source_managers/base.py
+++ b/llama_deploy/apiserver/source_managers/base.py
@@ -1,6 +1,16 @@
 from abc import ABC, abstractmethod
+from enum import Enum, auto
 
 from llama_deploy.apiserver.deployment_config_parser import DeploymentConfig
+
+
+class SyncPolicy(Enum):
+    """Define the sync behaviour in case the destination target exists."""
+
+    REPLACE = auto()
+    MERGE = auto()
+    SKIP = auto()
+    FAIL = auto()
 
 
 class SourceManager(ABC):
@@ -11,7 +21,10 @@ class SourceManager(ABC):
 
     @abstractmethod
     def sync(
-        self, source: str, destination: str | None = None
+        self,
+        source: str,
+        destination: str | None = None,
+        sync_policy: SyncPolicy = SyncPolicy.REPLACE,
     ) -> None:  # pragma: no cover
         """Fetches resources from `source` so they can be used in a deployment.
 

--- a/llama_deploy/apiserver/source_managers/git.py
+++ b/llama_deploy/apiserver/source_managers/git.py
@@ -1,14 +1,21 @@
+from pathlib import Path
+from shutil import rmtree
 from typing import Any
 
 from git import Repo
 
-from .base import SourceManager
+from .base import SourceManager, SyncPolicy
 
 
 class GitSourceManager(SourceManager):
     """A SourceManager specialized for sources of type `git`."""
 
-    def sync(self, source: str, destination: str | None = None) -> None:
+    def sync(
+        self,
+        source: str,
+        destination: str | None = None,
+        sync_policy: SyncPolicy = SyncPolicy.REPLACE,
+    ) -> None:
         """Clones the repository at URL `source` into a local path `destination`.
 
         Args:
@@ -18,6 +25,10 @@ class GitSourceManager(SourceManager):
         """
         if not destination:
             raise ValueError("Destination cannot be empty")
+
+        if Path(destination).exists():
+            # FIXME: pull when SyncPolicy is MERGE
+            rmtree(destination)
 
         url, branch_name = self._parse_source(source)
         kwargs: dict[str, Any] = {"url": url, "to_path": destination}

--- a/llama_deploy/apiserver/source_managers/git.py
+++ b/llama_deploy/apiserver/source_managers/git.py
@@ -1,5 +1,5 @@
+import shutil
 from pathlib import Path
-from shutil import rmtree
 from typing import Any
 
 from git import Repo
@@ -28,7 +28,7 @@ class GitSourceManager(SourceManager):
 
         if Path(destination).exists():
             # FIXME: pull when SyncPolicy is MERGE
-            rmtree(destination)
+            shutil.rmtree(destination)
 
         url, branch_name = self._parse_source(source)
         kwargs: dict[str, Any] = {"url": url, "to_path": destination}

--- a/llama_deploy/apiserver/source_managers/local.py
+++ b/llama_deploy/apiserver/source_managers/local.py
@@ -25,19 +25,24 @@ class LocalSourceManager(SourceManager):
         if not destination:
             raise ValueError("Destination cannot be empty")
 
+        if Path(source).is_absolute():
+            raise ValueError("Source path must be relative to the deployment file")
+
         base = self._config.base_path or Path()
         final_path = base / source
         destination_path = Path(destination)
         dirs_exist_ok: bool = False
-        try:
-            if destination_path.exists():
-                # Path is a non-empty directory
-                if sync_policy == SyncPolicy.REPLACE:
-                    shutil.rmtree(destination)
-                elif sync_policy == SyncPolicy.MERGE:
-                    dirs_exist_ok = True
+        if destination_path.exists():
+            # Path is a non-empty directory
+            if sync_policy == SyncPolicy.REPLACE:
+                shutil.rmtree(destination_path)
+            elif sync_policy == SyncPolicy.MERGE:
+                dirs_exist_ok = True
 
-            shutil.copytree(final_path, destination, dirs_exist_ok=dirs_exist_ok)
+        try:
+            shutil.copytree(
+                final_path, destination_path / source, dirs_exist_ok=dirs_exist_ok
+            )
         except Exception as e:
             msg = f"Unable to copy {source} into {destination}: {e}"
             raise ValueError(msg) from e

--- a/llama_deploy/apiserver/source_managers/local.py
+++ b/llama_deploy/apiserver/source_managers/local.py
@@ -19,6 +19,9 @@ class LocalSourceManager(SourceManager):
             source: The filesystem path to the folder containing the source code.
             destination: The path in the local filesystem where to copy the source directory.
         """
+        if sync_policy == SyncPolicy.SKIP:
+            return
+
         if not destination:
             raise ValueError("Destination cannot be empty")
 
@@ -32,8 +35,6 @@ class LocalSourceManager(SourceManager):
                     shutil.rmtree(destination)
                 elif sync_policy == SyncPolicy.MERGE:
                     dirs_exist_ok = True
-                elif sync_policy == SyncPolicy.SKIP:
-                    return
 
             shutil.copytree(final_path, destination, dirs_exist_ok=dirs_exist_ok)
         except Exception as e:

--- a/llama_deploy/apiserver/source_managers/local.py
+++ b/llama_deploy/apiserver/source_managers/local.py
@@ -25,7 +25,8 @@ class LocalSourceManager(SourceManager):
         if not destination:
             raise ValueError("Destination cannot be empty")
 
-        final_path = self._config.base_path / source
+        base = self._config.base_path or Path()
+        final_path = base / source
         destination_path = Path(destination)
         dirs_exist_ok: bool = False
         try:

--- a/llama_deploy/cli/__init__.py
+++ b/llama_deploy/cli/__init__.py
@@ -6,7 +6,7 @@ from .config import config as config_cmd
 from .deploy import deploy as deploy_cmd
 from .internal.config import DEFAULT_PROFILE_NAME, load_config
 from .run import run as run_cmd
-from .serve import serve
+from .serve import serve as serve_cmd
 from .sessions import sessions as sessions_cmd
 from .status import status as status_cmd
 
@@ -79,6 +79,6 @@ def llamactl(
 llamactl.add_command(config_cmd)
 llamactl.add_command(deploy_cmd)
 llamactl.add_command(run_cmd)
-llamactl.add_command(serve)
+llamactl.add_command(serve_cmd)
 llamactl.add_command(sessions_cmd)
 llamactl.add_command(status_cmd)

--- a/llama_deploy/cli/__init__.py
+++ b/llama_deploy/cli/__init__.py
@@ -6,6 +6,7 @@ from .config import config as config_cmd
 from .deploy import deploy as deploy_cmd
 from .internal.config import DEFAULT_PROFILE_NAME, load_config
 from .run import run as run_cmd
+from .serve import serve
 from .sessions import sessions as sessions_cmd
 from .status import status as status_cmd
 
@@ -75,8 +76,9 @@ def llamactl(
         click.echo(ctx.get_help())  # show the help if no subcommand was provided
 
 
+llamactl.add_command(config_cmd)
 llamactl.add_command(deploy_cmd)
 llamactl.add_command(run_cmd)
-llamactl.add_command(status_cmd)
+llamactl.add_command(serve)
 llamactl.add_command(sessions_cmd)
-llamactl.add_command(config_cmd)
+llamactl.add_command(status_cmd)

--- a/llama_deploy/cli/serve.py
+++ b/llama_deploy/cli/serve.py
@@ -45,7 +45,7 @@ def serve(local: bool, deployment_file: Path | None) -> None:
             for attempt in retrying:
                 with attempt:
                     client.sync.apiserver.deployments.create(
-                        deployment_file.open("rb"), skip_sync=local
+                        deployment_file.open("rb"), local=local
                     )
         except RetryError:
             uvicorn_p.terminate()

--- a/llama_deploy/cli/serve.py
+++ b/llama_deploy/cli/serve.py
@@ -1,21 +1,51 @@
+import threading
+from pathlib import Path
+
 import click
 import uvicorn
 from prometheus_client import start_http_server
+from tenacity import Retrying, stop_after_attempt, wait_fixed
 
+from llama_deploy import Client
 from llama_deploy.apiserver import settings
 
 
 @click.command()
-@click.option("--skip-sync", is_flag=True)
-def serve(skip_sync: bool) -> None:
-@click.option("--skip-sync", is_flag=True)
-def serve(skip_sync: bool) -> None:
+@click.option("--local", is_flag=True)
+@click.argument(
+    "deployment_file",
+    required=False,
+    type=click.Path(dir_okay=False, resolve_path=True, path_type=Path),  # type: ignore
+)
+def serve(local: bool, deployment_file: Path | None) -> None:
     """Run the API Server in the foreground."""
     if settings.prometheus_enabled:
         start_http_server(settings.prometheus_port)
 
-    uvicorn.run(
-        "llama_deploy.apiserver:app",
-        host=settings.host,
-        port=settings.port,
+    if deployment_file:
+        settings.deployments_path = deployment_file.parent
+
+    server = uvicorn.Server(
+        uvicorn.Config(
+            "llama_deploy.apiserver:app",
+            host="localhost",
+            port=4501,
+        )
     )
+    t = threading.Thread(target=server.run)
+    t.daemon = True
+    t.start()
+
+    if deployment_file:
+        client = Client()
+        retrying = Retrying(stop=stop_after_attempt(5), wait=wait_fixed(1))
+        for attempt in retrying:
+            with attempt:
+                client.sync.apiserver.deployments.create(
+                    deployment_file.open("rb"), skip_sync=local
+                )
+
+        try:
+            t.join()
+        except KeyboardInterrupt:
+            print("Shutting down...")

--- a/llama_deploy/cli/serve.py
+++ b/llama_deploy/cli/serve.py
@@ -8,6 +8,8 @@ from llama_deploy.apiserver import settings
 @click.command()
 @click.option("--skip-sync", is_flag=True)
 def serve(skip_sync: bool) -> None:
+@click.option("--skip-sync", is_flag=True)
+def serve(skip_sync: bool) -> None:
     """Run the API Server in the foreground."""
     if settings.prometheus_enabled:
         start_http_server(settings.prometheus_port)

--- a/llama_deploy/cli/serve.py
+++ b/llama_deploy/cli/serve.py
@@ -9,6 +9,8 @@ from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 from llama_deploy import Client
 from llama_deploy.apiserver import settings
 
+RETRY_WAIT_SECONDS = 1
+
 
 @click.command()
 @click.option("--local", is_flag=True)
@@ -40,7 +42,9 @@ def serve(local: bool, deployment_file: Path | None) -> None:
 
     if deployment_file:
         client = Client()
-        retrying = Retrying(stop=stop_after_attempt(5), wait=wait_fixed(1))
+        retrying = Retrying(
+            stop=stop_after_attempt(5), wait=wait_fixed(RETRY_WAIT_SECONDS)
+        )
         try:
             for attempt in retrying:
                 with attempt:

--- a/llama_deploy/client/models/apiserver.py
+++ b/llama_deploy/client/models/apiserver.py
@@ -242,14 +242,14 @@ class DeploymentCollection(Collection):
     """A model representing a collection of deployments currently active."""
 
     async def create(
-        self, config: TextIO, reload: bool = False, skip_sync: bool = False
+        self, config: TextIO, reload: bool = False, local: bool = False
     ) -> Deployment:
         """Creates a new deployment from a deployment file.
 
         If `reload` is true, an existing deployment will be reloaded, otherwise
         an error will be raised.
 
-        If `skip_sync` is true, the sync managers won't attempt at syncing data.
+        If `local` is true, the sync managers won't attempt at syncing data.
         This is mostly for supporting local development.
 
         Example:
@@ -265,7 +265,7 @@ class DeploymentCollection(Collection):
             "POST",
             create_url,
             files=files,
-            params={"reload": reload, "skip_sync": skip_sync},
+            params={"reload": reload, "local": local},
             verify=not self.client.disable_ssl,
             timeout=self.client.timeout,
         )

--- a/llama_deploy/client/models/apiserver.py
+++ b/llama_deploy/client/models/apiserver.py
@@ -241,11 +241,16 @@ class Deployment(Model):
 class DeploymentCollection(Collection):
     """A model representing a collection of deployments currently active."""
 
-    async def create(self, config: TextIO, reload: bool = False) -> Deployment:
+    async def create(
+        self, config: TextIO, reload: bool = False, skip_sync: bool = False
+    ) -> Deployment:
         """Creates a new deployment from a deployment file.
 
         If `reload` is true, an existing deployment will be reloaded, otherwise
         an error will be raised.
+
+        If `skip_sync` is true, the sync managers won't attempt at syncing data.
+        This is mostly for supporting local development.
 
         Example:
             ```
@@ -260,7 +265,7 @@ class DeploymentCollection(Collection):
             "POST",
             create_url,
             files=files,
-            params={"reload": reload},
+            params={"reload": reload, "skip_sync": skip_sync},
             verify=not self.client.disable_ssl,
             timeout=self.client.timeout,
         )

--- a/tests/apiserver/data/env_variables.yaml
+++ b/tests/apiserver/data/env_variables.yaml
@@ -18,3 +18,6 @@ services:
       VAR_2: y
     env-files:
       - .env
+    source:
+      type: local
+      name: workflow

--- a/tests/apiserver/data/example.yaml
+++ b/tests/apiserver/data/example.yaml
@@ -52,6 +52,3 @@ services:
       type: docker
       name: myorg/myimage:latest
     port: 1313
-
-  memory:
-    name: Chat Memory

--- a/tests/apiserver/data/python_dependencies.yaml
+++ b/tests/apiserver/data/python_dependencies.yaml
@@ -16,3 +16,6 @@ services:
     python-dependencies:
       - "llama-index-core<1"
       - "llama-index-llms-openai"
+    source:
+      type: local
+      name: test

--- a/tests/apiserver/data/service_ports.yaml
+++ b/tests/apiserver/data/service_ports.yaml
@@ -5,10 +5,19 @@ control-plane: {}
 services:
   no-port:
     name: No Port
+    source:
+      type: local
+      name: workflow
 
   has-port:
     name: Has Port
     port: 9999
+    source:
+      type: local
+      name: workflow
 
   no-port-again:
     name: Again no Port
+    source:
+      type: local
+      name: workflow

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -48,7 +48,7 @@ def test_create_deployment(http_client: TestClient, data_path: Path) -> None:
             )
 
         assert response.status_code == 200
-        mocked_manager.deploy.assert_awaited_with(actual_config, False)
+        mocked_manager.deploy.assert_awaited_with(actual_config, False, False)
 
 
 def test_create_deployment_task_not_found(

--- a/tests/apiserver/source_managers/test_git.py
+++ b/tests/apiserver/source_managers/test_git.py
@@ -39,3 +39,13 @@ def test_sync(config: DeploymentConfig) -> None:
         repo_mock.clone_from.assert_called_with(
             to_path="dest", url="source", multi_options=["-b branch", "--single-branch"]
         )
+
+
+def test_sync_dir_exists(config: DeploymentConfig, tmp_path: Path) -> None:
+    sm = GitSourceManager(config)
+    with mock.patch("llama_deploy.apiserver.source_managers.git.Repo"):
+        with mock.patch(
+            "llama_deploy.apiserver.source_managers.git.shutil"
+        ) as shutil_mock:
+            sm.sync("source", str(tmp_path))
+            shutil_mock.rmtree.assert_called_once()

--- a/tests/apiserver/source_managers/test_local.py
+++ b/tests/apiserver/source_managers/test_local.py
@@ -35,7 +35,7 @@ def test_relative_path(tmp_path: Path, data_path: Path) -> None:
     sm = LocalSourceManager(config)
 
     sm.sync("workflow", str(tmp_path))
-    fnames = list(f.name for f in tmp_path.iterdir())
+    fnames = list(f.name for f in (tmp_path / "workflow").iterdir())
     assert "workflow_test.py" in fnames
     assert "__init__.py" in fnames
 
@@ -45,7 +45,7 @@ def test_relative_path_dot(tmp_path: Path, data_path: Path) -> None:
     sm = LocalSourceManager(config)
 
     sm.sync("./workflow", str(tmp_path))
-    fnames = list(f.name for f in tmp_path.iterdir())
+    fnames = list(f.name for f in (tmp_path / "workflow").iterdir())
     assert "workflow_test.py" in fnames
     assert "__init__.py" in fnames
 
@@ -55,7 +55,5 @@ def test_absolute_path(tmp_path: Path, data_path: Path) -> None:
     wf_dir = data_path / "workflow"
     sm = LocalSourceManager(config)
 
-    sm.sync(str(wf_dir.absolute()), str(tmp_path))
-    fnames = list(f.name for f in tmp_path.iterdir())
-    assert "workflow_test.py" in fnames
-    assert "__init__.py" in fnames
+    with pytest.raises(ValueError):
+        sm.sync(str(wf_dir.absolute()), str(tmp_path))

--- a/tests/apiserver/test_config_parser.py
+++ b/tests/apiserver/test_config_parser.py
@@ -42,9 +42,6 @@ def do_assert(config: DeploymentConfig) -> None:
     assert wf_config.source.name == "myorg/myimage:latest"
     assert wf_config.port == 1313
 
-    wf_config = config.services["memory"]
-    assert wf_config.name == "Chat Memory"
-
 
 def test_load_config_file(data_path: Path) -> None:
     config = DeploymentConfig.from_yaml(data_path / "example.yaml")

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -205,7 +205,7 @@ def test__install_dependencies_raises(data_path: Path) -> None:
 
 
 def test_manager_ctor() -> None:
-    m = Manager()
+    m = Manager(deployments_path=Path(".deployments"))
     assert str(m._deployments_path) == ".deployments"
     assert len(m._deployments) == 0
     m = Manager(deployments_path=Path("foo"))
@@ -419,7 +419,6 @@ async def test_start_ui_server_success(data_path: Path, tmp_path: Path) -> None:
     # Mock the necessary components
     with (
         mock.patch("llama_deploy.apiserver.deployment.SOURCE_MANAGERS") as sm_dict,
-        mock.patch("llama_deploy.apiserver.deployment.rmtree"),
         mock.patch(
             "llama_deploy.apiserver.deployment.asyncio.create_subprocess_exec"
         ) as mock_subprocess,

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -13,6 +13,7 @@ from llama_deploy.apiserver.deployment import Deployment, DeploymentError, Manag
 from llama_deploy.apiserver.deployment_config_parser import (
     DeploymentConfig,
 )
+from llama_deploy.apiserver.source_managers.base import SyncPolicy
 from llama_deploy.control_plane import ControlPlaneConfig, ControlPlaneServer
 from llama_deploy.message_queues import AWSMessageQueueConfig, SimpleMessageQueue
 
@@ -438,12 +439,13 @@ async def test_start_ui_server_success(data_path: Path, tmp_path: Path) -> None:
         mock_os.environ.copy.return_value = {"PATH": "/some/path"}
 
         # Run the method
-        await deployment._start_ui_server()
+        await deployment._start_ui_server(skip_sync=False)
 
         # Verify source manager was used correctly
         source_manager_mock.sync.assert_called_once_with(
             "https://github.com/run-llama/llama_deploy.git",
             str((tmp_path / "test-deployment" / "ui").resolve()),
+            SyncPolicy.REPLACE,
         )
 
         # Verify npm commands were executed
@@ -469,7 +471,7 @@ async def test_start_ui_server_missing_config(
     deployment = Deployment(config=deployment_config, root_path=tmp_path)
 
     with pytest.raises(ValueError, match="missing ui configuration settings"):
-        await deployment._start_ui_server()
+        await deployment._start_ui_server(skip_sync=False)
 
 
 @pytest.mark.asyncio
@@ -481,4 +483,4 @@ async def test_start_ui_server_missing_source(
     deployment = Deployment(config=deployment_config, root_path=tmp_path)
 
     with pytest.raises(ValueError, match="source must be defined"):
-        await deployment._start_ui_server()
+        await deployment._start_ui_server(skip_sync=False)

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -206,15 +206,13 @@ def test__install_dependencies_raises(data_path: Path) -> None:
 
 
 def test_manager_ctor() -> None:
-    m = Manager(deployments_path=Path(".deployments"))
-    assert str(m._deployments_path) == ".deployments"
-    assert len(m._deployments) == 0
-    m = Manager(deployments_path=Path("foo"))
-    assert str(m._deployments_path) == "foo"
-    assert len(m._deployments) == 0
-    assert len(m.deployment_names) == 0
-    assert m.get_deployment("foo") is None
-    assert m._simple_message_queue_server is None
+    m = Manager()
+    assert m.deployments_path.name == "deployments"
+    assert m._max_deployments == 10
+
+    m = Manager(max_deployments=42)
+    assert m.deployments_path.name == "deployments"
+    assert m._max_deployments == 42
 
 
 @pytest.mark.asyncio
@@ -252,6 +250,7 @@ async def test_manager_deploy(data_path: Path) -> None:
         "llama_deploy.apiserver.deployment.Deployment"
     ) as mocked_deployment:
         m = Manager()
+        m._deployments_path = Path()
         await m.deploy(config)
         mocked_deployment.assert_called_once()
         assert m.deployment_names == ["TestDeployment"]

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -36,7 +36,7 @@ def test_deployment_ctor(data_path: Path, mock_importlib: Any, tmp_path: Path) -
 
         sm_dict["git"].return_value.sync.assert_called_once()
         assert d.name == "TestDeployment"
-        assert d.path == tmp_path
+        assert d.path.name == "TestDeployment"
         assert type(d._control_plane) is ControlPlaneServer
         assert len(d._workflow_services) == 1
         assert d.service_names == ["test-workflow"]
@@ -436,7 +436,7 @@ async def test_start_ui_server_success(data_path: Path, tmp_path: Path) -> None:
         mock_os.environ.copy.return_value = {"PATH": "/some/path"}
 
         # Run the method
-        await deployment._start_ui_server(skip_sync=False)
+        await deployment._start_ui_server()
 
         # Verify source manager was used correctly
         source_manager_mock.sync.assert_called_once()
@@ -464,7 +464,7 @@ async def test_start_ui_server_missing_config(
     deployment = Deployment(config=deployment_config, root_path=tmp_path)
 
     with pytest.raises(ValueError, match="missing ui configuration settings"):
-        await deployment._start_ui_server(skip_sync=False)
+        await deployment._start_ui_server()
 
 
 @pytest.mark.asyncio
@@ -476,4 +476,4 @@ async def test_start_ui_server_missing_source(
     deployment = Deployment(config=deployment_config, root_path=tmp_path)
 
     with pytest.raises(ValueError, match="source must be defined"):
-        await deployment._start_ui_server(skip_sync=False)
+        await deployment._start_ui_server()

--- a/tests/apiserver/test_server.py
+++ b/tests/apiserver/test_server.py
@@ -4,7 +4,6 @@ from typing import Any
 from unittest import mock
 
 import pytest
-
 from llama_deploy.apiserver.server import lifespan
 from llama_deploy.apiserver.settings import ApiserverSettings
 
@@ -19,7 +18,6 @@ async def test_lifespan(
     caplog: Any,
     data_path: Path,
 ) -> None:  # type: ignore
-    actual_settings = ApiserverSettings(rc_path=tmp_path)
     source_file = data_path / "git_service.yaml"
     config_file = tmp_path / "test.yml"
     with open(config_file, "w") as f:

--- a/tests/apiserver/test_server.py
+++ b/tests/apiserver/test_server.py
@@ -10,9 +10,7 @@ from llama_deploy.apiserver.server import lifespan
 
 @pytest.mark.asyncio
 @mock.patch("llama_deploy.apiserver.server.manager")
-@mock.patch("llama_deploy.apiserver.server.shutil")
 async def test_lifespan(
-    mocked_shutil: Any,
     mocked_manager: Any,
     tmp_path: Path,
     caplog: Any,
@@ -23,11 +21,12 @@ async def test_lifespan(
     with open(config_file, "w") as f:
         f.write(source_file.read_text())
 
+    mocked_manager.serve = mock.AsyncMock()
     with mock.patch("llama_deploy.apiserver.server.settings") as mocked_settings:
         mocked_settings.rc_path = tmp_path
         mocked_settings.deployments_path = tmp_path / "foo/bar"
         caplog.set_level(logging.INFO)
-        async with lifespan(mock.MagicMock()):
+        async with lifespan(mock.AsyncMock()):
             pass
 
         assert f"deployments folder: {mocked_settings.deployments_path}" in caplog.text
@@ -36,4 +35,3 @@ async def test_lifespan(
         )
         assert f"Deploying startup configuration from {config_file}" in caplog.text
         mocked_manager.serve.assert_called_once()
-        mocked_shutil.rmtree.assert_called_once()

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -1,0 +1,212 @@
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+from click.testing import CliRunner
+from tenacity import RetryError
+
+from llama_deploy.apiserver import settings
+from llama_deploy.cli.serve import serve
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Fixture for invoking command-line interfaces."""
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def ensure_settings_defaults():  # type: ignore
+    """Fixture to ensure settings are reset before each test."""
+    original_prometheus_enabled = settings.prometheus_enabled
+    original_prometheus_port = settings.prometheus_port
+    yield
+    settings.prometheus_enabled = original_prometheus_enabled
+    settings.prometheus_port = original_prometheus_port
+
+
+def test_serve_no_deployment_file(runner: CliRunner) -> None:
+    """Test serve command without a deployment file."""
+    with (
+        patch("subprocess.Popen") as mock_popen,
+        patch("llama_deploy.cli.serve.start_http_server") as mock_start_http_server,
+    ):
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+        settings.prometheus_enabled = False
+
+        result = runner.invoke(serve)
+
+        assert result.exit_code == 0
+        expected_env = os.environ.copy()
+        mock_popen.assert_called_once_with(
+            [
+                "uvicorn",
+                "llama_deploy.apiserver:app",
+                "--host",
+                "localhost",
+                "--port",
+                "4501",
+            ],
+            env=expected_env,
+        )
+        mock_start_http_server.assert_not_called()
+        mock_process.wait.assert_called_once()
+
+
+def test_serve_prometheus_enabled(runner: CliRunner) -> None:
+    """Test serve command with Prometheus enabled."""
+    with (
+        patch("subprocess.Popen") as mock_popen,
+        patch("llama_deploy.cli.serve.start_http_server") as mock_start_http_server,
+    ):
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+        settings.prometheus_enabled = True
+        settings.prometheus_port = 9090  # Example port
+
+        result = runner.invoke(serve)
+
+        assert result.exit_code == 0
+        mock_start_http_server.assert_called_once_with(9090)
+        mock_popen.assert_called_once()  # Args checked in other tests
+        mock_process.wait.assert_called_once()
+
+
+def test_serve_with_deployment_file(runner: CliRunner, tmp_path: Path) -> None:
+    """Test serve command with a deployment file."""
+    deployment_file = tmp_path / "test_deployment.yaml"
+    deployment_file.write_text("dummy content")
+
+    with (
+        patch("subprocess.Popen") as mock_popen,
+        patch("llama_deploy.cli.serve.start_http_server") as mock_start_http_server,
+        patch("llama_deploy.cli.serve.Client") as mock_client_class,
+        patch(
+            "pathlib.Path.open", mock_open(read_data=b"dummy content")
+        ) as mock_file_open,
+    ):
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        mock_sdk_client = MagicMock()
+        mock_client_class.return_value = mock_sdk_client
+        settings.prometheus_enabled = False
+
+        result = runner.invoke(serve, [str(deployment_file)])
+
+        assert result.exit_code == 0
+
+        expected_env = os.environ.copy()
+        expected_env["LLAMA_DEPLOY_APISERVER_DEPLOYMENTS_PATH"] = str(tmp_path)
+        mock_popen.assert_called_once_with(
+            [
+                "uvicorn",
+                "llama_deploy.apiserver:app",
+                "--host",
+                "localhost",
+                "--port",
+                "4501",
+            ],
+            env=expected_env,
+        )
+        mock_start_http_server.assert_not_called()
+        mock_client_class.assert_called_once_with()
+        mock_file_open.assert_called_once_with("rb")
+        mock_sdk_client.sync.apiserver.deployments.create.assert_called_once()
+        # Check the first argument of the create call (the file object)
+        assert (
+            mock_sdk_client.sync.apiserver.deployments.create.call_args[0][0]
+            == mock_file_open.return_value
+        )
+        # Check the local keyword argument
+        assert (
+            mock_sdk_client.sync.apiserver.deployments.create.call_args[1]["local"]
+            is False
+        )
+
+        mock_process.wait.assert_called_once()
+
+
+def test_serve_with_deployment_file_and_local_flag(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Test serve command with a deployment file and --local flag."""
+    deployment_file = tmp_path / "test_deployment_local.yaml"
+    deployment_file.write_text("dummy local content")
+
+    with (
+        patch("subprocess.Popen") as mock_popen,
+        patch("llama_deploy.cli.serve.start_http_server"),
+        patch("llama_deploy.cli.serve.Client") as mock_client_class,
+        patch("pathlib.Path.open", mock_open(read_data=b"dummy content")),
+    ):
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        mock_sdk_client = MagicMock()
+        mock_client_class.return_value = mock_sdk_client
+        settings.prometheus_enabled = False
+
+        result = runner.invoke(serve, ["--local", str(deployment_file)])
+
+        assert result.exit_code == 0
+        mock_sdk_client.sync.apiserver.deployments.create.assert_called_once()
+        assert (
+            mock_sdk_client.sync.apiserver.deployments.create.call_args[1]["local"]
+            is True
+        )
+        mock_process.wait.assert_called_once()
+
+
+def test_serve_deployment_creation_fails(runner: CliRunner, tmp_path: Path) -> None:
+    """Test serve command when deployment creation fails."""
+    deployment_file = tmp_path / "test_deployment_fail.yaml"
+    deployment_file.write_text("dummy fail content")
+
+    with (
+        patch("subprocess.Popen") as mock_popen,
+        patch("llama_deploy.cli.serve.start_http_server"),
+        patch("llama_deploy.cli.serve.Client") as mock_client_class,
+        patch("pathlib.Path.open", mock_open(read_data=b"dummy content")),
+        patch("llama_deploy.cli.serve.RETRY_WAIT_SECONDS", 0.01),
+    ):
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        mock_sdk_client = MagicMock()
+        mock_sdk_client.sync.apiserver.deployments.create.side_effect = RetryError(
+            "Failed to deploy"  # type: ignore
+        )
+        mock_client_class.return_value = mock_sdk_client
+        settings.prometheus_enabled = False
+
+        result = runner.invoke(serve, [str(deployment_file)])
+
+        assert result.exit_code == 1
+        assert "Failed to create deployment" in result.output
+        mock_client_class.assert_called_once_with()
+        mock_sdk_client.sync.apiserver.deployments.create.assert_called()  # Called 5 times due to retry
+        assert mock_sdk_client.sync.apiserver.deployments.create.call_count == 5
+        mock_process.terminate.assert_called_once()
+        mock_process.wait.assert_not_called()
+
+
+def test_serve_keyboard_interrupt(runner: CliRunner) -> None:
+    """Test serve command handles KeyboardInterrupt."""
+    with (
+        patch("subprocess.Popen") as mock_popen,
+        patch("llama_deploy.cli.serve.start_http_server"),
+    ):
+        mock_process = MagicMock()
+        mock_process.wait.side_effect = KeyboardInterrupt
+        mock_popen.return_value = mock_process
+        settings.prometheus_enabled = False
+
+        result = runner.invoke(serve)
+
+        # Exit code might be 0 or other codes depending on how Click handles KeyboardInterrupt
+        # Checking for the message is more reliable here.
+        assert "Shutting down..." in result.output
+        mock_process.wait.assert_called_once()

--- a/tests/client/models/test_apiserver.py
+++ b/tests/client/models/test_apiserver.py
@@ -218,7 +218,7 @@ async def test_task_deployment_collection_create(client: Any) -> None:
         "POST",
         "http://localhost:4501/deployments/create",
         files={"config_file": "some config"},
-        params={"reload": False, "skip_sync": False},
+        params={"reload": False, "local": False},
         verify=True,
         timeout=120.0,
     )

--- a/tests/client/models/test_apiserver.py
+++ b/tests/client/models/test_apiserver.py
@@ -218,7 +218,7 @@ async def test_task_deployment_collection_create(client: Any) -> None:
         "POST",
         "http://localhost:4501/deployments/create",
         files={"config_file": "some config"},
-        params={"reload": False},
+        params={"reload": False, "skip_sync": False},
         verify=True,
         timeout=120.0,
     )


### PR DESCRIPTION
General concept:
- Added a new command `serve` to `llamactl` to boostrap a local LlamaDeploy instance running a specific deployment.
- When passing `--local` to `llamactl serve`, no code will be copied around, so changes to the local code will be picked up at the next restart (there's a plan to introduce a file watcher to make iterations even faster)
- Prior to this PR the concept of "local run" didn't exist, so I had to instruct several components to not try to sync the code listed in a deployment file. Several parts of the `apiserver` now takes a boolean flag called `local`.

For more specific comments to the code, see my review.