### PR TITLE
feat!: improve local source manager

### DIFF
--- a/docs/docs/module_guides/llama_deploy/10_getting_started.md
+++ b/docs/docs/module_guides/llama_deploy/10_getting_started.md
@@ -54,10 +54,11 @@ services:
     source:
       # In this case, we instruct LlamaDeploy to look in the local filesystem
       type: local
-      # The path in the local filesystem where to look. This assumes there's an src folder in the
-      # current working directory containing the file workflow.py we created previously
+      # The path relative to this deployment config file where to look for the code. This assumes
+      # there's an src folder along with the config file containing the file workflow.py we created previously
       name: ./src
-    # This assumes the file workflow.py contains a variable called `echo_workflow` containing our workflow instance
+    # This assumes the Python module workflow.py contains a variable called `echo_workflow`
+    # containing our workflow instance
     path: workflow:echo_workflow
 ```
 

--- a/e2e_tests/apiserver/deployments/deployment2.yml
+++ b/e2e_tests/apiserver/deployments/deployment2.yml
@@ -11,5 +11,5 @@ services:
     host: localhost
     source:
       type: local
-      name: e2e_tests/apiserver/deployments/src
-    path: e2e_tests/apiserver/deployments/src:my_workflow
+      name: src
+    path: src:my_workflow

--- a/e2e_tests/apiserver/deployments/deployment2.yml
+++ b/e2e_tests/apiserver/deployments/deployment2.yml
@@ -10,6 +10,6 @@ services:
     port: 8002
     host: localhost
     source:
-      type: git
-      name: https://github.com/run-llama/llama_deploy.git
+      type: local
+      name: e2e_tests/apiserver/deployments/src
     path: e2e_tests/apiserver/deployments/src:my_workflow

--- a/e2e_tests/apiserver/deployments/deployment_env_local.yml
+++ b/e2e_tests/apiserver/deployments/deployment_env_local.yml
@@ -10,10 +10,10 @@ services:
     name: Workflow
     source:
       type: local
-      name: ./e2e_tests/apiserver/deployments/src
+      name: src
     env:
       VAR_1: x # this gets overwritten because VAR_1 also exists in the provided .env
       VAR_2: y
     env-files:
-      - ./e2e_tests/apiserver/deployments/src/.env # relative to source path
-    path: ./e2e_tests/apiserver/deployments/src/workflow_env:workflow
+      - src/.env # relative to source path
+    path: src/workflow_env:workflow

--- a/e2e_tests/apiserver/deployments/deployment_hitl.yml
+++ b/e2e_tests/apiserver/deployments/deployment_hitl.yml
@@ -10,5 +10,5 @@ services:
     name: HITL Workflow
     source:
       type: local
-      name: ./e2e_tests/apiserver/deployments/src
-    path: ./e2e_tests/apiserver/deployments/src/workflow_hitl:workflow
+      name: src
+    path: src/workflow_hitl:workflow

--- a/e2e_tests/apiserver/deployments/deployment_streaming.yml
+++ b/e2e_tests/apiserver/deployments/deployment_streaming.yml
@@ -10,5 +10,5 @@ services:
     name: Streaming Workflow
     source:
       type: local
-      name: ./e2e_tests/apiserver/deployments/src
-    path: ./e2e_tests/apiserver/deployments/src/workflow:streaming_workflow
+      name: src
+    path: src/workflow:streaming_workflow

--- a/e2e_tests/apiserver/test_deploy.py
+++ b/e2e_tests/apiserver/test_deploy.py
@@ -6,8 +6,9 @@ import pytest
 @pytest.mark.asyncio
 async def test_deploy(apiserver, client):
     here = Path(__file__).parent
-    with open(here / "deployments" / "deployment1.yml") as f:
-        await client.apiserver.deployments.create(f)
+    deployment_fp = here / "deployments" / "deployment1.yml"
+    with open(deployment_fp) as f:
+        await client.apiserver.deployments.create(f, base_path=deployment_fp.parent)
 
     status = await client.apiserver.status()
     assert "TestDeployment1" in status.deployments
@@ -15,8 +16,9 @@ async def test_deploy(apiserver, client):
 
 def test_deploy_sync(apiserver, client):
     here = Path(__file__).parent
-    with open(here / "deployments" / "deployment1.yml") as f:
-        client.sync.apiserver.deployments.create(f)
+    deployment_fp = here / "deployments" / "deployment1.yml"
+    with open(deployment_fp) as f:
+        client.sync.apiserver.deployments.create(f, base_path=deployment_fp.parent)
 
     assert "TestDeployment1" in client.sync.apiserver.status().deployments
 

--- a/e2e_tests/apiserver/test_deploy.py
+++ b/e2e_tests/apiserver/test_deploy.py
@@ -24,8 +24,11 @@ def test_deploy_sync(apiserver, client):
 @pytest.mark.asyncio
 async def test_deploy_local(apiserver, client):
     here = Path(__file__).parent
-    with open(here / "deployments" / "deployment2.yml") as f:
-        await client.apiserver.deployments.create(f)
+    deployment_fp = here / "deployments" / "deployment2.yml"
+    with open(deployment_fp) as f:
+        await client.apiserver.deployments.create(
+            f, base_path=str(deployment_fp.parent.resolve())
+        )
 
     status = await client.apiserver.status()
     assert "TestDeployment2" in status.deployments

--- a/e2e_tests/apiserver/test_deploy.py
+++ b/e2e_tests/apiserver/test_deploy.py
@@ -15,7 +15,17 @@ async def test_deploy(apiserver, client):
 
 def test_deploy_sync(apiserver, client):
     here = Path(__file__).parent
-    with open(here / "deployments" / "deployment2.yml") as f:
+    with open(here / "deployments" / "deployment1.yml") as f:
         client.sync.apiserver.deployments.create(f)
 
-    assert "TestDeployment2" in client.sync.apiserver.status().deployments
+    assert "TestDeployment1" in client.sync.apiserver.status().deployments
+
+
+@pytest.mark.asyncio
+async def test_deploy_local(apiserver, client):
+    here = Path(__file__).parent
+    with open(here / "deployments" / "deployment2.yml") as f:
+        await client.apiserver.deployments.create(f)
+
+    status = await client.apiserver.status()
+    assert "TestDeployment2" in status.deployments

--- a/e2e_tests/apiserver/test_env_vars_git.py
+++ b/e2e_tests/apiserver/test_env_vars_git.py
@@ -7,9 +7,9 @@ import pytest
 @pytest.mark.asyncio
 async def test_read_env_vars_git(apiserver, client):
     here = Path(__file__).parent
-
-    with open(here / "deployments" / "deployment_env_git.yml") as f:
-        await client.apiserver.deployments.create(f)
+    deployment_fp = here / "deployments" / "deployment_env_git.yml"
+    with open(deployment_fp) as f:
+        await client.apiserver.deployments.create(f, base_path=deployment_fp.parent)
         await asyncio.sleep(5)
 
     session = await client.core.sessions.create()

--- a/e2e_tests/apiserver/test_env_vars_local.py
+++ b/e2e_tests/apiserver/test_env_vars_local.py
@@ -7,9 +7,9 @@ import pytest
 @pytest.mark.asyncio
 async def test_read_env_vars_local(apiserver, client):
     here = Path(__file__).parent
-
-    with open(here / "deployments" / "deployment_env_local.yml") as f:
-        await client.apiserver.deployments.create(f)
+    deployment_fp = here / "deployments" / "deployment_env_local.yml"
+    with open(deployment_fp) as f:
+        await client.apiserver.deployments.create(f, base_path=deployment_fp.parent)
         await asyncio.sleep(5)
 
     session = await client.core.sessions.create()

--- a/e2e_tests/apiserver/test_hitl.py
+++ b/e2e_tests/apiserver/test_hitl.py
@@ -11,9 +11,11 @@ from llama_deploy.types import EventDefinition, TaskDefinition
 @pytest.mark.asyncio
 async def test_hitl(apiserver, client):
     here = Path(__file__).parent
-
-    with open(here / "deployments" / "deployment_hitl.yml") as f:
-        deployment = await client.apiserver.deployments.create(f)
+    deployment_fp = here / "deployments" / "deployment_hitl.yml"
+    with open(deployment_fp) as f:
+        deployment = await client.apiserver.deployments.create(
+            f, base_path=deployment_fp.parent
+        )
         await asyncio.sleep(5)
 
     tasks = deployment.tasks

--- a/e2e_tests/apiserver/test_reload.py
+++ b/e2e_tests/apiserver/test_reload.py
@@ -9,16 +9,22 @@ from llama_deploy.types import TaskDefinition
 @pytest.mark.asyncio
 async def test_reload(apiserver, client):
     here = Path(__file__).parent
-    with open(here / "deployments" / "deployment_reload1.yml") as f:
-        deployment = await client.apiserver.deployments.create(f)
+    deployment_fp = here / "deployments" / "deployment_reload1.yml"
+    with open(deployment_fp) as f:
+        deployment = await client.apiserver.deployments.create(
+            f, base_path=deployment_fp.parent
+        )
         await asyncio.sleep(3)
 
     tasks = deployment.tasks
     res = await tasks.run(TaskDefinition(input='{"data": "bar"}'))
     assert res == "I have received:bar"
 
-    with open(here / "deployments" / "deployment_reload2.yml") as f:
-        deployment = await client.apiserver.deployments.create(f, reload=True)
+    deployment_fp = here / "deployments" / "deployment_reload2.yml"
+    with open(deployment_fp) as f:
+        deployment = await client.apiserver.deployments.create(
+            f, base_path=deployment_fp.parent, reload=True
+        )
         await asyncio.sleep(3)
 
     tasks = deployment.tasks

--- a/e2e_tests/apiserver/test_streaming.py
+++ b/e2e_tests/apiserver/test_streaming.py
@@ -9,9 +9,11 @@ from llama_deploy.types import TaskDefinition
 @pytest.mark.asyncio
 async def test_stream(apiserver, client):
     here = Path(__file__).parent
-
-    with open(here / "deployments" / "deployment_streaming.yml") as f:
-        deployment = await client.apiserver.deployments.create(f)
+    deployment_fp = here / "deployments" / "deployment_streaming.yml"
+    with open(deployment_fp) as f:
+        deployment = await client.apiserver.deployments.create(
+            f, base_path=deployment_fp.parent
+        )
         await asyncio.sleep(5)
 
     tasks = deployment.tasks
@@ -23,4 +25,4 @@ async def test_stream(apiserver, client):
     assert len(read_events) == 3
     # the workflow produces events sequentially, so here we can assume events arrived in order
     for i, ev in enumerate(read_events):
-        assert ev["text"] == f"message number {i+1}"
+        assert ev["text"] == f"message number {i + 1}"

--- a/examples/llamacloud/google_drive/README.md
+++ b/examples/llamacloud/google_drive/README.md
@@ -107,8 +107,8 @@ services:
     source:
       # In this case, we instruct LlamaDeploy to look in the local filesystem
       type: local
-      # The path in the local filesystem where to look. This assumes there's an src folder in the
-      # current working directory containing the file workflow.py we created previously
+      # The path relative to this deployment config file where to look for the code. This assumes
+      # there's an src folder along with the config file containing the file workflow.py we created previously
       name: ./src
     # This assumes the file workflow.py contains a variable called `echo_workflow` containing our workflow instance
     path: workflow:llamacloud_workflow

--- a/examples/llamacloud/google_drive/deployment.yml
+++ b/examples/llamacloud/google_drive/deployment.yml
@@ -12,8 +12,8 @@ services:
     source:
       # In this case, we instruct LlamaDeploy to look in the local filesystem
       type: local
-      # The path in the local filesystem where to look. This assumes there's an src folder in the
-      # current working directory containing the file workflow.py we created previously
+      # The path relative to this deployment config file where to look for the code. This assumes
+      # there's an src folder along with the config file containing the file workflow.py we created previously
       name: ./src
     # This assumes the file workflow.py contains a variable called `echo_workflow` containing our workflow instance
     path: workflow:llamacloud_workflow

--- a/examples/quick_start/README.md
+++ b/examples/quick_start/README.md
@@ -44,8 +44,8 @@ services:
     source:
       # In this case, we instruct LlamaDeploy to look in the local filesystem
       type: local
-      # The path in the local filesystem where to look. This assumes there's an src folder in the
-      # current working directory containing the file workflow.py we created previously
+      # The path relative to this deployment config file where to look for the code. This assumes
+      # there's an src folder along with the config file containing the file workflow.py we created previously
       name: ./src
     # This assumes the file workflow.py contains a variable called `echo_workflow` containing our workflow instance
     path: workflow:echo_workflow

--- a/examples/quick_start/quick_start.yml
+++ b/examples/quick_start/quick_start.yml
@@ -11,7 +11,7 @@ services:
     source:
       type: local
       name: src
-    path: workflow:echo_workflow
+    path: src/workflow:echo_workflow
 
 ui:
   name: My Nextjs App

--- a/examples/quick_start/quick_start.yml
+++ b/examples/quick_start/quick_start.yml
@@ -16,5 +16,5 @@ services:
 ui:
   name: My Nextjs App
   source:
-    type: local # could be git
+    type: local
     name: ui

--- a/llama_deploy/apiserver/deployment_config_parser.py
+++ b/llama_deploy/apiserver/deployment_config_parser.py
@@ -75,7 +75,6 @@ class DeploymentConfig(BaseModel):
     message_queue: MessageQueueConfig | None = Field(None, alias="message-queue")
     default_service: str | None = Field(None, alias="default-service")
     services: dict[str, Service]
-    base_path: Path | None = Field(None, alias="base-path")
     ui: UIService | None = None
 
     @classmethod
@@ -89,7 +88,5 @@ class DeploymentConfig(BaseModel):
         """Read config data from a yaml file."""
         with open(path, "r") as yaml_file:
             config = yaml.safe_load(yaml_file) or {}
-            if config.get("base-path") is None:
-                config["base-path"] = path.parent
 
         return cls(**config)

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -36,7 +36,7 @@ async def read_deployment(deployment_name: str) -> DeploymentDefinition:
 
 @deployments_router.post("/create")
 async def create_deployment(
-    base_path: str,
+    base_path: str = ".",
     config_file: UploadFile = File(...),
     reload: bool = False,
     local: bool = False,

--- a/llama_deploy/apiserver/routers/deployments.py
+++ b/llama_deploy/apiserver/routers/deployments.py
@@ -36,13 +36,14 @@ async def read_deployment(deployment_name: str) -> DeploymentDefinition:
 
 @deployments_router.post("/create")
 async def create_deployment(
+    base_path: str,
     config_file: UploadFile = File(...),
     reload: bool = False,
     local: bool = False,
 ) -> DeploymentDefinition:
     """Creates a new deployment by uploading a configuration file."""
     config = DeploymentConfig.from_yaml_bytes(await config_file.read())
-    await manager.deploy(config, reload, local)
+    await manager.deploy(config, base_path, reload, local)
 
     return DeploymentDefinition(name=config.name)
 

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -18,9 +18,10 @@ manager = Manager()
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
     apiserver_state.state("starting")
 
-    t = asyncio.create_task(manager.serve(deployments_path=settings.deployments_path))
+    manager.set_deployments_path(settings.deployments_path)
+    t = asyncio.create_task(manager.serve())
 
-    logger.info(f"deployments folder: {settings.deployments_path}")
+    logger.info(f"deployments folder: {manager.deployments_path}")
     logger.info(f"rc folder: {settings.rc_path}")
 
     if settings.rc_path.exists():

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -20,6 +20,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
 
     manager.set_deployments_path(settings.deployments_path)
     t = asyncio.create_task(manager.serve())
+    await asyncio.sleep(0)
 
     logger.info(f"deployments folder: {manager.deployments_path}")
     logger.info(f"rc folder: {settings.rc_path}")

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -33,7 +33,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
             try:
                 logger.info(f"Deploying startup configuration from {yaml_file}")
                 config = DeploymentConfig.from_yaml(yaml_file)
-                await manager.deploy(config)
+                await manager.deploy(config, base_path=str(settings.rc_path))
             except Exception as e:
                 logger.error(f"Failed to deploy {yaml_file}: {str(e)}")
 

--- a/llama_deploy/apiserver/source_managers/base.py
+++ b/llama_deploy/apiserver/source_managers/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum, auto
+from pathlib import Path
 
 from llama_deploy.apiserver.deployment_config_parser import DeploymentConfig
 
@@ -16,8 +17,9 @@ class SyncPolicy(Enum):
 class SourceManager(ABC):
     """Protocol to be implemented by classes responsible for managing Deployment sources."""
 
-    def __init__(self, config: DeploymentConfig) -> None:
+    def __init__(self, config: DeploymentConfig, base_path: Path | None = None) -> None:
         self._config = config
+        self._base_path = base_path
 
     @abstractmethod
     def sync(

--- a/llama_deploy/apiserver/source_managers/local.py
+++ b/llama_deploy/apiserver/source_managers/local.py
@@ -28,7 +28,7 @@ class LocalSourceManager(SourceManager):
         if Path(source).is_absolute():
             raise ValueError("Source path must be relative to the deployment file")
 
-        base = self._config.base_path or Path()
+        base = self._base_path or Path()
         final_path = base / source
         destination_path = Path(destination)
         dirs_exist_ok: bool = False

--- a/llama_deploy/cli/serve.py
+++ b/llama_deploy/cli/serve.py
@@ -49,7 +49,9 @@ def serve(local: bool, deployment_file: Path | None) -> None:
             for attempt in retrying:
                 with attempt:
                     client.sync.apiserver.deployments.create(
-                        deployment_file.open("rb"), local=local
+                        deployment_file.open("rb"),
+                        base_path=deployment_file.parent,
+                        local=local,
                     )
         except RetryError:
             uvicorn_p.terminate()

--- a/llama_deploy/client/models/apiserver.py
+++ b/llama_deploy/client/models/apiserver.py
@@ -242,7 +242,7 @@ class DeploymentCollection(Collection):
     """A model representing a collection of deployments currently active."""
 
     async def create(
-        self, config: TextIO, reload: bool = False, local: bool = False
+        self, config: TextIO, base_path: str, reload: bool = False, local: bool = False
     ) -> Deployment:
         """Creates a new deployment from a deployment file.
 
@@ -265,7 +265,7 @@ class DeploymentCollection(Collection):
             "POST",
             create_url,
             files=files,
-            params={"reload": reload, "local": local},
+            params={"reload": reload, "local": local, "base_path": base_path},
             verify=not self.client.disable_ssl,
             timeout=self.client.timeout,
         )

--- a/tests/apiserver/conftest.py
+++ b/tests/apiserver/conftest.py
@@ -29,7 +29,7 @@ def mocked_deployment(data_path: Path, mock_importlib: Any) -> Iterator[Deployme
     config = DeploymentConfig.from_yaml(data_path / "git_service.yaml")
     with mock.patch("llama_deploy.apiserver.deployment.SOURCE_MANAGERS") as sm_dict:
         sm_dict["git"] = mock.MagicMock()
-        yield Deployment(config=config, root_path=Path("."))
+        yield Deployment(config=config, base_path=data_path, deployment_path=Path("."))
 
 
 @pytest.fixture

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -48,7 +48,7 @@ def test_create_deployment(http_client: TestClient, data_path: Path) -> None:
             )
 
         assert response.status_code == 200
-        mocked_manager.deploy.assert_awaited_with(actual_config, False, False)
+        mocked_manager.deploy.assert_awaited_with(actual_config, ".", False, False)
 
 
 def test_create_deployment_task_not_found(

--- a/tests/apiserver/source_managers/test_local.py
+++ b/tests/apiserver/source_managers/test_local.py
@@ -33,7 +33,7 @@ def test_sync_error(config: DeploymentConfig) -> None:
 
 def test_relative_path(tmp_path: Path, data_path: Path) -> None:
     config = DeploymentConfig.from_yaml(data_path / "local.yaml")
-    sm = LocalSourceManager(config)
+    sm = LocalSourceManager(config, data_path)
 
     sm.sync("workflow", str(tmp_path))
     fnames = list(f.name for f in (tmp_path / "workflow").iterdir())
@@ -43,7 +43,7 @@ def test_relative_path(tmp_path: Path, data_path: Path) -> None:
 
 def test_relative_path_dot(tmp_path: Path, data_path: Path) -> None:
     config = DeploymentConfig.from_yaml(data_path / "local.yaml")
-    sm = LocalSourceManager(config)
+    sm = LocalSourceManager(config, data_path)
 
     sm.sync("./workflow", str(tmp_path))
     fnames = list(f.name for f in (tmp_path / "workflow").iterdir())

--- a/tests/apiserver/test_server.py
+++ b/tests/apiserver/test_server.py
@@ -25,6 +25,7 @@ async def test_lifespan(
     with mock.patch("llama_deploy.apiserver.server.settings") as mocked_settings:
         mocked_settings.rc_path = tmp_path
         mocked_settings.deployments_path = tmp_path / "foo/bar"
+        mocked_manager.deployments_path = mocked_settings.deployments_path
         caplog.set_level(logging.INFO)
         async with lifespan(mock.AsyncMock()):
             pass

--- a/tests/client/models/test_apiserver.py
+++ b/tests/client/models/test_apiserver.py
@@ -212,13 +212,13 @@ async def test_task_deployment_collection_create(client: Any) -> None:
     client.request.return_value = mock.MagicMock(json=lambda: {"name": "deployment"})
 
     coll = DeploymentCollection(client=client, items={})
-    await coll.create(io.StringIO("some config"))
+    await coll.create(io.StringIO("some config"), base_path="tmp")
 
     client.request.assert_awaited_with(
         "POST",
         "http://localhost:4501/deployments/create",
         files={"config_file": "some config"},
-        params={"reload": False, "local": False},
+        params={"reload": False, "local": False, "base_path": "tmp"},
         verify=True,
         timeout=120.0,
     )


### PR DESCRIPTION
There was a bit of confusion in the way local sources for a deployment are supposed to work, hopefully this should improve clarity. A few changes were made:
- Removed `base_path` from the deployment configuration. That's the path that's supposed to tell where the config file is, it doesn't make sense to keep it in the config file itself.
- Added `base_path` explicitly to the Deployment interface. Since a deployment configuration can be requested over the wire with no config file, in that case it's the user responsibility to define it
- Renamed `root_path` to `deployment_path` in the `Deployment` api. This should help clarify that `deployment_path` is where the workflows code is copied at deploy time.
- Changes to the `Deployment` class are breaking and this reflects on the Python client.
- The CLI will try to infer `base_path` whenever possible.