### PR TITLE
chore: better naming for deployment config fields

### DIFF
--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -234,7 +234,7 @@ class Deployment:
         destination = self._deployment_path.resolve()
         source_manager = SOURCE_MANAGERS[source.type](self._config, self._base_path)
         policy = SyncPolicy.SKIP if self._local else SyncPolicy.REPLACE
-        source_manager.sync(source.name, str(destination), policy)
+        source_manager.sync(source.location, str(destination), policy)
 
         install = await asyncio.create_subprocess_exec(
             "pnpm", "install", cwd=destination / "ui"
@@ -269,7 +269,7 @@ class Deployment:
                 continue
 
             # FIXME: Momentarily assuming everything is a workflow
-            if service_config.path is None:
+            if service_config.import_path is None:
                 msg = "path field in service definition must be set"
                 raise ValueError(msg)
 
@@ -288,7 +288,7 @@ class Deployment:
             destination = self._deployment_path.resolve()
             source_manager = SOURCE_MANAGERS[source.type](config, self._base_path)
             policy = SyncPolicy.SKIP if self._local else SyncPolicy.REPLACE
-            source_manager.sync(source.name, str(destination), policy)
+            source_manager.sync(source.location, str(destination), policy)
 
             # Install dependencies
             service_state.labels(self._name, service_id).state("installing")
@@ -298,7 +298,7 @@ class Deployment:
             self._set_environment_variables(service_config, destination)
 
             # Search for a workflow instance in the service path
-            module_path_str, workflow_name = service_config.path.split(":")
+            module_path_str, workflow_name = service_config.import_path.split(":")
             module_path = Path(module_path_str)
             module_name = module_path.name
             pythonpath = (destination / module_path.parent).resolve()

--- a/tests/apiserver/test_config_parser.py
+++ b/tests/apiserver/test_config_parser.py
@@ -16,8 +16,8 @@ def do_assert(config: DeploymentConfig) -> None:
     assert wf_config.name == "My Python Workflow"
     assert wf_config.source
     assert wf_config.source.type == "git"
-    assert wf_config.source.name == "git@github.com/myorg/myrepo"
-    assert wf_config.path == "src/python/app"
+    assert wf_config.source.location == "git@github.com/myorg/myrepo"
+    assert wf_config.import_path == "src/python/app"
     assert wf_config.port == 1313
     assert wf_config.python_dependencies
     assert len(wf_config.python_dependencies) == 3
@@ -28,8 +28,8 @@ def do_assert(config: DeploymentConfig) -> None:
     assert wf_config.name == "My LITS Workflow"
     assert wf_config.source
     assert wf_config.source.type == "git"
-    assert wf_config.source.name == "git@github.com/myorg/myrepo"
-    assert wf_config.path == "src/ts/app"
+    assert wf_config.source.location == "git@github.com/myorg/myrepo"
+    assert wf_config.import_path == "src/ts/app"
     assert wf_config.port == 1313
     assert wf_config.ts_dependencies
     assert len(wf_config.ts_dependencies) == 2
@@ -39,7 +39,7 @@ def do_assert(config: DeploymentConfig) -> None:
     assert wf_config.name == "My additional service"
     assert wf_config.source
     assert wf_config.source.type == "docker"
-    assert wf_config.source.name == "myorg/myimage:latest"
+    assert wf_config.source.location == "myorg/myimage:latest"
     assert wf_config.port == 1313
 
 

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -46,7 +46,7 @@ def test_deployment_ctor(data_path: Path, mock_importlib: Any, tmp_path: Path) -
 
 def test_deployment_ctor_missing_service_path(data_path: Path, tmp_path: Path) -> None:
     config = DeploymentConfig.from_yaml(data_path / "git_service.yaml")
-    config.services["test-workflow"].path = None
+    config.services["test-workflow"].import_path = None
     with pytest.raises(
         ValueError, match="path field in service definition must be set"
     ):


### PR DESCRIPTION
Discussed offline, in a deployment config like
```yaml
name: LocalDeploymentRelativePath

services:
  test-workflow:
    name: Test Workflow
    source:
      type: local
      name: workflow
    path: workflow:my_workflow
```
the fields `name` and `path` are confusing, so this PR renames them to `location` and `import_path` respectively, resulting in the following
```yaml
name: LocalDeploymentRelativePath

services:
  test-workflow:
    name: Test Workflow
    source:
      type: local
      location: workflow
    import_path: workflow:my_workflow
```