### PR TITLE
chore: simplify import structure

### DIFF
--- a/e2e_tests/basic_hitl/conftest.py
+++ b/e2e_tests/basic_hitl/conftest.py
@@ -4,10 +4,8 @@ import time
 
 import pytest
 
-from llama_deploy import (
-    ControlPlaneConfig,
-    WorkflowServiceConfig,
-)
+from llama_deploy.control_plane import ControlPlaneConfig
+from llama_deploy.services import WorkflowServiceConfig
 
 from ..utils import deploy_workflow
 from .workflow import HumanInTheLoopWorkflow

--- a/e2e_tests/basic_hitl/test_run_client.py
+++ b/e2e_tests/basic_hitl/test_run_client.py
@@ -4,7 +4,7 @@ import time
 import pytest
 from llama_index.core.workflow.events import HumanResponseEvent
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 
 
 def test_run_client(services):

--- a/e2e_tests/basic_session/conftest.py
+++ b/e2e_tests/basic_session/conftest.py
@@ -4,10 +4,8 @@ import time
 
 import pytest
 
-from llama_deploy import (
-    ControlPlaneConfig,
-    WorkflowServiceConfig,
-)
+from llama_deploy.control_plane import ControlPlaneConfig
+from llama_deploy.services import WorkflowServiceConfig
 
 from ..utils import deploy_workflow
 from .workflow import SessionWorkflow

--- a/e2e_tests/basic_session/test_run_client.py
+++ b/e2e_tests/basic_session/test_run_client.py
@@ -1,6 +1,6 @@
 import pytest
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 
 
 def test_run_client(workflow):

--- a/e2e_tests/basic_streaming/conftest.py
+++ b/e2e_tests/basic_streaming/conftest.py
@@ -4,10 +4,8 @@ import time
 
 import pytest
 
-from llama_deploy import (
-    ControlPlaneConfig,
-    WorkflowServiceConfig,
-)
+from llama_deploy.control_plane import ControlPlaneConfig
+from llama_deploy.services import WorkflowServiceConfig
 
 from ..utils import deploy_workflow
 from .workflow import StreamingWorkflow

--- a/e2e_tests/basic_streaming/test_run_client.py
+++ b/e2e_tests/basic_streaming/test_run_client.py
@@ -1,6 +1,6 @@
 import pytest
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 
 
 def test_run_client(services):

--- a/e2e_tests/basic_workflow/conftest.py
+++ b/e2e_tests/basic_workflow/conftest.py
@@ -4,10 +4,8 @@ import time
 
 import pytest
 
-from llama_deploy import (
-    ControlPlaneConfig,
-    WorkflowServiceConfig,
-)
+from llama_deploy.control_plane import ControlPlaneConfig
+from llama_deploy.services import WorkflowServiceConfig
 
 from ..utils import deploy_workflow
 from .workflow import OuterWorkflow

--- a/e2e_tests/basic_workflow/test_run_client.py
+++ b/e2e_tests/basic_workflow/test_run_client.py
@@ -1,6 +1,6 @@
 import pytest
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 
 
 def test_run_client(workflow):

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -4,7 +4,8 @@ import time
 
 import pytest
 
-from llama_deploy import ControlPlaneConfig, SimpleMessageQueueConfig
+from llama_deploy.control_plane import ControlPlaneConfig
+from llama_deploy.message_queues.simple import SimpleMessageQueueConfig
 
 from .utils import deploy_core
 

--- a/e2e_tests/core/conftest.py
+++ b/e2e_tests/core/conftest.py
@@ -4,10 +4,8 @@ import time
 
 import pytest
 
-from llama_deploy import (
-    ControlPlaneConfig,
-    WorkflowServiceConfig,
-)
+from llama_deploy.control_plane import ControlPlaneConfig
+from llama_deploy.services import WorkflowServiceConfig
 
 from ..utils import deploy_workflow
 from .workflow import BasicWorkflow

--- a/e2e_tests/core/test_services.py
+++ b/e2e_tests/core/test_services.py
@@ -3,9 +3,7 @@ import multiprocessing
 
 import pytest
 
-from llama_deploy import (
-    Client,
-)
+from llama_deploy.client import Client
 from llama_deploy.types.core import ServiceDefinition
 
 from .conftest import run_async_workflow
@@ -70,16 +68,6 @@ async def test_service_restart(core):
     # run again, same session
     result = await session.run("basic")
     assert result == "n/a_result"
-
-    # assert len(await client.core.services.list()) == 1
-    # await client.core.services.deregister("basic")
-    # assert len(await client.core.services.list()) == 0
-
-    # new_s = await client.core.services.register(
-    #     ServiceDefinition(service_name="another_basic", description="none")
-    # )
-    # assert new_s.id == "another_basic"
-    # assert len(await client.core.services.list()) == 1
 
     p.kill()
     p.join()

--- a/e2e_tests/message_queues/kafka/conftest.py
+++ b/e2e_tests/message_queues/kafka/conftest.py
@@ -6,11 +6,9 @@ from pathlib import Path
 
 import pytest
 
-from llama_deploy import (
-    ControlPlaneConfig,
-    WorkflowServiceConfig,
-)
+from llama_deploy.control_plane import ControlPlaneConfig
 from llama_deploy.message_queues import KafkaMessageQueue, KafkaMessageQueueConfig
+from llama_deploy.services import WorkflowServiceConfig
 
 from ...utils import deploy_core, deploy_workflow
 from .workflow import BasicWorkflow

--- a/e2e_tests/message_queues/kafka/test_message_queue.py
+++ b/e2e_tests/message_queues/kafka/test_message_queue.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 from llama_deploy.types import QueueMessage
 
 

--- a/e2e_tests/message_queues/rabbitmq/conftest.py
+++ b/e2e_tests/message_queues/rabbitmq/conftest.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 import pytest
 
-from llama_deploy import ControlPlaneConfig, WorkflowServiceConfig
+from llama_deploy.control_plane import ControlPlaneConfig
 from llama_deploy.message_queues import RabbitMQMessageQueue, RabbitMQMessageQueueConfig
+from llama_deploy.services import WorkflowServiceConfig
 
 from ...utils import deploy_core, deploy_workflow
 from .workflow import BasicWorkflow

--- a/e2e_tests/message_queues/rabbitmq/test_message_queue.py
+++ b/e2e_tests/message_queues/rabbitmq/test_message_queue.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 from llama_deploy.types import QueueMessage
 
 

--- a/e2e_tests/message_queues/redis/conftest.py
+++ b/e2e_tests/message_queues/redis/conftest.py
@@ -7,11 +7,9 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 
-from llama_deploy import (
-    ControlPlaneConfig,
-    WorkflowServiceConfig,
-)
+from llama_deploy.control_plane import ControlPlaneConfig
 from llama_deploy.message_queues import RedisMessageQueue, RedisMessageQueueConfig
+from llama_deploy.services import WorkflowServiceConfig
 
 from ...utils import deploy_core, deploy_workflow
 from .workflow import BasicWorkflow

--- a/e2e_tests/message_queues/redis/test_message_queue.py
+++ b/e2e_tests/message_queues/redis/test_message_queue.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 from llama_deploy.message_queues.redis import RedisMessageQueue
 from llama_deploy.types import QueueMessage
 

--- a/e2e_tests/message_queues/simple/conftest.py
+++ b/e2e_tests/message_queues/simple/conftest.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 import pytest_asyncio
 
-from llama_deploy import (
+from llama_deploy.message_queues.simple import (
     SimpleMessageQueue,
     SimpleMessageQueueConfig,
     SimpleMessageQueueServer,

--- a/e2e_tests/message_queues/simple/test_message_queue.py
+++ b/e2e_tests/message_queues/simple/test_message_queue.py
@@ -2,9 +2,7 @@ import asyncio
 
 import pytest
 
-from llama_deploy import (
-    SimpleMessageQueue,
-)
+from llama_deploy.message_queues import SimpleMessageQueue
 from llama_deploy.types import QueueMessage
 
 

--- a/e2e_tests/message_queues/simple/test_server.py
+++ b/e2e_tests/message_queues/simple/test_server.py
@@ -2,7 +2,10 @@ import asyncio
 
 import pytest
 
-from llama_deploy import SimpleMessageQueueConfig, SimpleMessageQueueServer
+from llama_deploy.message_queues import (
+    SimpleMessageQueueConfig,
+    SimpleMessageQueueServer,
+)
 
 
 @pytest.mark.asyncio

--- a/llama_deploy/__init__.py
+++ b/llama_deploy/__init__.py
@@ -1,18 +1,4 @@
-# configure logger
 import logging
-
-from llama_deploy.client import Client
-from llama_deploy.control_plane import ControlPlaneConfig, ControlPlaneServer
-from llama_deploy.message_queues import (
-    SimpleMessageQueue,
-    SimpleMessageQueueConfig,
-    SimpleMessageQueueServer,
-)
-from llama_deploy.services import (
-    WorkflowService,
-    WorkflowServiceConfig,
-)
-from llama_deploy.types import QueueMessage
 
 root_logger = logging.getLogger("llama_deploy")
 
@@ -23,21 +9,3 @@ root_logger.addHandler(console_handler)
 
 root_logger.setLevel(logging.INFO)
 root_logger.propagate = True
-
-
-__all__ = [
-    # client
-    "Client",
-    # services
-    "WorkflowService",
-    "WorkflowServiceConfig",
-    # messages
-    "QueueMessage",
-    # message queues
-    "SimpleMessageQueueServer",
-    "SimpleMessageQueueConfig",
-    "SimpleMessageQueue",
-    # control planes
-    "ControlPlaneServer",
-    "ControlPlaneConfig",
-]

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -13,14 +13,9 @@ import httpx
 from dotenv import dotenv_values
 from tenacity import AsyncRetrying, RetryError, wait_exponential
 
-from llama_deploy import (
-    Client,
-    ControlPlaneServer,
-    SimpleMessageQueueServer,
-    WorkflowService,
-    WorkflowServiceConfig,
-)
 from llama_deploy.apiserver.source_managers.base import SyncPolicy
+from llama_deploy.client import Client
+from llama_deploy.control_plane import ControlPlaneServer
 from llama_deploy.message_queues import (
     AbstractMessageQueue,
     KafkaMessageQueue,
@@ -29,6 +24,8 @@ from llama_deploy.message_queues import (
     SimpleMessageQueue,
     SimpleMessageQueueConfig,
 )
+from llama_deploy.message_queues.simple import SimpleMessageQueueServer
+from llama_deploy.services import WorkflowService, WorkflowServiceConfig
 
 from .deployment_config_parser import (
     DeploymentConfig,

--- a/llama_deploy/cli/deploy.py
+++ b/llama_deploy/cli/deploy.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 
 from .internal.config import ConfigProfile
 

--- a/llama_deploy/cli/run.py
+++ b/llama_deploy/cli/run.py
@@ -2,7 +2,7 @@ import json
 
 import click
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 from llama_deploy.types import TaskDefinition
 
 from .internal.config import ConfigProfile

--- a/llama_deploy/cli/serve.py
+++ b/llama_deploy/cli/serve.py
@@ -6,8 +6,8 @@ import click
 from prometheus_client import start_http_server
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
-from llama_deploy import Client
 from llama_deploy.apiserver import settings
+from llama_deploy.client import Client
 
 RETRY_WAIT_SECONDS = 1
 

--- a/llama_deploy/cli/sessions.py
+++ b/llama_deploy/cli/sessions.py
@@ -1,6 +1,6 @@
 import click
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 
 from .internal.config import ConfigProfile
 

--- a/llama_deploy/cli/status.py
+++ b/llama_deploy/cli/status.py
@@ -1,6 +1,6 @@
 import click
 
-from llama_deploy import Client
+from llama_deploy.client import Client
 from llama_deploy.types.apiserver import StatusEnum
 
 from .internal.config import ConfigProfile

--- a/llama_deploy/control_plane/server.py
+++ b/llama_deploy/control_plane/server.py
@@ -49,8 +49,8 @@ class ControlPlaneServer:
 
     Examples:
         ```python
-        from llama_deploy import ControlPlaneServer
-        from llama_deploy import SimpleMessageQueue, SimpleOrchestrator
+        from llama_deploy.control_plane import ControlPlaneServer
+        from llama_deploy.message_queue import SimpleMessageQueue
         from llama_index.llms.openai import OpenAI
 
         control_plane = ControlPlaneServer(

--- a/tests/message_queues/test_apache_kafka.py
+++ b/tests/message_queues/test_apache_kafka.py
@@ -3,11 +3,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from llama_deploy import QueueMessage
 from llama_deploy.message_queues.apache_kafka import (
     KafkaMessageQueue,
     KafkaMessageQueueConfig,
 )
+from llama_deploy.types import QueueMessage
 
 try:
     import aiokafka

--- a/tests/message_queues/test_rabbitmq.py
+++ b/tests/message_queues/test_rabbitmq.py
@@ -6,11 +6,11 @@ import pytest
 from aio_pika import DeliveryMode
 from aio_pika import Message as AioPikaMessage
 
-from llama_deploy import QueueMessage
 from llama_deploy.message_queues.rabbitmq import (
     RabbitMQMessageQueue,
     RabbitMQMessageQueueConfig,
 )
+from llama_deploy.types import QueueMessage
 
 
 def test_config_init() -> None:

--- a/tests/services/test_network_workflow.py
+++ b/tests/services/test_network_workflow.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from llama_index.core.workflow import StartEvent
 
-from llama_deploy import ControlPlaneConfig
+from llama_deploy.control_plane import ControlPlaneConfig
 from llama_deploy.services.network_service_manager import (
     NetworkServiceManager,
     ServiceNotFoundError,


### PR DESCRIPTION
Avoid importing too many symbols from the root `__init__.py`.