### PR TITLE
feat: get nextjs port from deployment file

### DIFF
--- a/examples/quick_start/quick_start.yml
+++ b/examples/quick_start/quick_start.yml
@@ -15,6 +15,7 @@ services:
 
 ui:
   name: My Nextjs App
+  port: 3001
   source:
     type: local
     name: ui

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -217,6 +217,8 @@ class Deployment:
         env = os.environ.copy()
         env["LLAMA_DEPLOY_NEXTJS_BASE_PATH"] = f"/deployments/{self._config.name}/ui"
         env["LLAMA_DEPLOY_NEXTJS_DEPLOYMENT_NAME"] = self._config.name
+        # Override PORT and force using 3000
+        env["PORT"] = str(self._config.ui.port)
 
         process = await asyncio.create_subprocess_exec(
             "pnpm",

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -217,7 +217,7 @@ class Deployment:
         env = os.environ.copy()
         env["LLAMA_DEPLOY_NEXTJS_BASE_PATH"] = f"/deployments/{self._config.name}/ui"
         env["LLAMA_DEPLOY_NEXTJS_DEPLOYMENT_NAME"] = self._config.name
-        # Override PORT and force using 3000
+        # Override PORT and force using the one from the deployment.yaml file
         env["PORT"] = str(self._config.ui.port)
 
         process = await asyncio.create_subprocess_exec(

--- a/llama_deploy/apiserver/deployment_config_parser.py
+++ b/llama_deploy/apiserver/deployment_config_parser.py
@@ -96,7 +96,10 @@ class Service(BaseModel):
 
 
 class UIService(Service):
-    pass
+    port: int | None = Field(
+        default=3000,
+        description="The TCP port to use for the nextjs server",
+    )
 
 
 class DeploymentConfig(BaseModel):

--- a/tests/apiserver/routers/test_deployments.py
+++ b/tests/apiserver/routers/test_deployments.py
@@ -24,6 +24,7 @@ def mock_manager() -> Generator[MagicMock]:
     """Mock the manager to return a deployment when requested."""
     with patch("llama_deploy.apiserver.routers.deployments.manager") as mock_mgr:
         mock_deployment = MagicMock()
+        mock_deployment._config.ui.port = 3000
         mock_mgr.get_deployment.return_value = mock_deployment
         yield mock_mgr
 


### PR DESCRIPTION
Let users control the TCP port used to run nextjs if a `ui` service was configured.