### PR TITLE
Followup fixes for uv dependencies

### DIFF
--- a/docker/run_autodeploy.py
+++ b/docker/run_autodeploy.py
@@ -45,8 +45,7 @@ def setup_repo(
         run_process(["git", "pull", "origin", "main"], cwd=str(dest_dir.absolute()))
 
 
-def copy_sources(work_dir: Path, deployment_file_path: Path) -> None:
-    app_folder = deployment_file_path.parent
+def copy_sources(work_dir: Path, app_folder: Path) -> None:
     for item in app_folder.iterdir():
         if item.is_dir():
             # For directories, use copytree with dirs_exist_ok=True
@@ -92,8 +91,9 @@ if __name__ == "__main__":
     copy_sources(work_dir, work_dir / CLONED_REPO_FOLDER)
     shutil.rmtree(work_dir / CLONED_REPO_FOLDER)
 
-    # Ready to go
-    os.environ["LLAMA_DEPLOY_APISERVER_RC_PATH"] = str(work_dir / deployment_file_path)
+    # settings has already been loaded, so mutate it directly rather than setting the
+    # LLAMA_DEPLOY_APISERVER_RC_PATH environment variable
+    settings.rc_path = (work_dir / deployment_file_path).parent
     uvicorn.run(
         "llama_deploy.apiserver.app:app",
         host=settings.host,

--- a/docker/run_autodeploy.py
+++ b/docker/run_autodeploy.py
@@ -89,11 +89,11 @@ if __name__ == "__main__":
             with open(deployment_file_abspath, "w") as f:
                 yaml.safe_dump(data, f)
 
-    copy_sources(work_dir, deployment_file_abspath)
+    copy_sources(work_dir, work_dir / CLONED_REPO_FOLDER)
     shutil.rmtree(work_dir / CLONED_REPO_FOLDER)
 
     # Ready to go
-    os.environ["LLAMA_DEPLOY_APISERVER_RC_PATH"] = str(work_dir)
+    os.environ["LLAMA_DEPLOY_APISERVER_RC_PATH"] = str(work_dir / deployment_file_path)
     uvicorn.run(
         "llama_deploy.apiserver.app:app",
         host=settings.host,

--- a/docker/run_autodeploy.py
+++ b/docker/run_autodeploy.py
@@ -45,7 +45,8 @@ def setup_repo(
         run_process(["git", "pull", "origin", "main"], cwd=str(dest_dir.absolute()))
 
 
-def copy_sources(work_dir: Path, app_folder: Path) -> None:
+def copy_sources(work_dir: Path, deployment_file_path: Path) -> None:
+    app_folder = deployment_file_path.parent
     for item in app_folder.iterdir():
         if item.is_dir():
             # For directories, use copytree with dirs_exist_ok=True
@@ -88,12 +89,12 @@ if __name__ == "__main__":
             with open(deployment_file_abspath, "w") as f:
                 yaml.safe_dump(data, f)
 
-    copy_sources(work_dir, work_dir / CLONED_REPO_FOLDER)
+    copy_sources(work_dir, deployment_file_abspath)
     shutil.rmtree(work_dir / CLONED_REPO_FOLDER)
 
-    # settings has already been loaded, so mutate it directly rather than setting the
-    # LLAMA_DEPLOY_APISERVER_RC_PATH environment variable
-    settings.rc_path = (work_dir / deployment_file_path).parent
+    # update rc_path directly, as it has already been loaded, so setting the environment variable
+    # doesn't work
+    settings.rc_path = work_dir
     uvicorn.run(
         "llama_deploy.apiserver.app:app",
         host=settings.host,

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -207,7 +207,9 @@ class Deployment:
         # Sync the service source
         destination = self._deployment_path.resolve()
         source_manager = SOURCE_MANAGERS[source.type](self._config, self._base_path)
-        policy = SyncPolicy.SKIP if self._local else SyncPolicy.REPLACE
+        policy = source.sync_policy or (
+            SyncPolicy.SKIP if self._local else SyncPolicy.REPLACE
+        )
         source_manager.sync(source.location, str(destination), policy)
         installed_path = destination / source_manager.relative_path(source.location)
 

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -208,10 +208,11 @@ class Deployment:
         destination = self._deployment_path.resolve()
         source_manager = SOURCE_MANAGERS[source.type](self._config, self._base_path)
         policy = SyncPolicy.SKIP if self._local else SyncPolicy.REPLACE
-        source_manager.sync(source.location, str(destination / "ui"), policy)
+        source_manager.sync(source.location, str(destination), policy)
+        installed_path = destination / source_manager.relative_path(source.location)
 
         install = await asyncio.create_subprocess_exec(
-            "pnpm", "install", cwd=destination / "ui"
+            "pnpm", "install", cwd=installed_path
         )
         await install.wait()
 
@@ -225,7 +226,7 @@ class Deployment:
             "pnpm",
             "run",
             "dev",
-            cwd=destination / "ui",
+            cwd=installed_path,
             env=env,
         )
 

--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -208,10 +208,10 @@ class Deployment:
         destination = self._deployment_path.resolve()
         source_manager = SOURCE_MANAGERS[source.type](self._config, self._base_path)
         policy = SyncPolicy.SKIP if self._local else SyncPolicy.REPLACE
-        source_manager.sync(source.location, str(destination), policy)
+        source_manager.sync(source.location, str(destination / "ui"), policy)
 
         install = await asyncio.create_subprocess_exec(
-            "pnpm", "install", cwd=destination
+            "pnpm", "install", cwd=destination / "ui"
         )
         await install.wait()
 
@@ -225,7 +225,7 @@ class Deployment:
             "pnpm",
             "run",
             "dev",
-            cwd=destination,
+            cwd=destination / "ui",
             env=env,
         )
 

--- a/llama_deploy/apiserver/deployment_config_parser.py
+++ b/llama_deploy/apiserver/deployment_config_parser.py
@@ -1,8 +1,9 @@
 import sys
 import warnings
-from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Union
+from typing import Annotated, Any, Optional, Union
+
+from enum import Enum
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -39,11 +40,21 @@ class SourceType(str, Enum):
     local = "local"
 
 
+class SyncPolicy(Enum):
+    """Define the sync behaviour in case the destination target exists."""
+
+    REPLACE = "replace"
+    MERGE = "merge"
+    SKIP = "skip"
+    FAIL = "fail"
+
+
 class ServiceSource(BaseModel):
     """Configuration for the `source` parameter of a service."""
 
     type: SourceType
     location: str
+    sync_policy: Optional[SyncPolicy] = None
 
     @model_validator(mode="before")
     @classmethod

--- a/llama_deploy/apiserver/source_managers/base.py
+++ b/llama_deploy/apiserver/source_managers/base.py
@@ -1,17 +1,7 @@
 from abc import ABC, abstractmethod
-from enum import Enum, auto
 from pathlib import Path
 
-from llama_deploy.apiserver.deployment_config_parser import DeploymentConfig
-
-
-class SyncPolicy(Enum):
-    """Define the sync behaviour in case the destination target exists."""
-
-    REPLACE = auto()
-    MERGE = auto()
-    SKIP = auto()
-    FAIL = auto()
+from llama_deploy.apiserver.deployment_config_parser import DeploymentConfig, SyncPolicy
 
 
 class SourceManager(ABC):

--- a/llama_deploy/apiserver/source_managers/base.py
+++ b/llama_deploy/apiserver/source_managers/base.py
@@ -33,3 +33,11 @@ class SourceManager(ABC):
         Optionally uses `destination` to store data when this makes sense for the
         specific source type.
         """
+
+    def relative_path(self, source: str) -> str:
+        """Unfortunately, there's a difference in behavior of how the source managers sync.
+        The local source manager syncs the source into the <destination_path>/<source>, whereas
+        the git source manager just syncs the source into the <destination_path>. This is a temporary shim, since
+        changing this behavior is a breaking change to deployment.yaml configurations. Local source manager
+        overrides it. In a future major version, this behavior will be made consistent"""
+        return ""

--- a/llama_deploy/apiserver/source_managers/local.py
+++ b/llama_deploy/apiserver/source_managers/local.py
@@ -3,6 +3,10 @@ from pathlib import Path
 
 from .base import SourceManager, SyncPolicy
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class LocalSourceManager(SourceManager):
     """A SourceManager specialized for sources of type `local`."""
@@ -40,9 +44,7 @@ class LocalSourceManager(SourceManager):
                 dirs_exist_ok = True
 
         try:
-            shutil.copytree(
-                final_path, destination_path / source, dirs_exist_ok=dirs_exist_ok
-            )
+            shutil.copytree(final_path, destination_path, dirs_exist_ok=dirs_exist_ok)
         except Exception as e:
             msg = f"Unable to copy {source} into {destination}: {e}"
             raise ValueError(msg) from e

--- a/llama_deploy/apiserver/source_managers/local.py
+++ b/llama_deploy/apiserver/source_managers/local.py
@@ -3,10 +3,6 @@ from pathlib import Path
 
 from .base import SourceManager, SyncPolicy
 
-import logging
-
-logger = logging.getLogger(__name__)
-
 
 class LocalSourceManager(SourceManager):
     """A SourceManager specialized for sources of type `local`."""
@@ -44,7 +40,12 @@ class LocalSourceManager(SourceManager):
                 dirs_exist_ok = True
 
         try:
-            shutil.copytree(final_path, destination_path, dirs_exist_ok=dirs_exist_ok)
+            shutil.copytree(
+                final_path, destination_path / source, dirs_exist_ok=dirs_exist_ok
+            )
         except Exception as e:
             msg = f"Unable to copy {source} into {destination}: {e}"
             raise ValueError(msg) from e
+
+    def relative_path(self, source: str) -> str:
+        return source

--- a/tests/apiserver/source_managers/test_local.py
+++ b/tests/apiserver/source_managers/test_local.py
@@ -36,7 +36,7 @@ def test_relative_path(tmp_path: Path, data_path: Path) -> None:
     sm = LocalSourceManager(config, data_path)
 
     sm.sync("workflow", str(tmp_path))
-    fnames = list(f.name for f in (tmp_path / "workflow").iterdir())
+    fnames = list(f.name for f in (tmp_path).iterdir())
     assert "workflow_test.py" in fnames
     assert "__init__.py" in fnames
 
@@ -46,7 +46,7 @@ def test_relative_path_dot(tmp_path: Path, data_path: Path) -> None:
     sm = LocalSourceManager(config, data_path)
 
     sm.sync("./workflow", str(tmp_path))
-    fnames = list(f.name for f in (tmp_path / "workflow").iterdir())
+    fnames = list(f.name for f in (tmp_path).iterdir())
     assert "workflow_test.py" in fnames
     assert "__init__.py" in fnames
 

--- a/tests/apiserver/source_managers/test_local.py
+++ b/tests/apiserver/source_managers/test_local.py
@@ -36,7 +36,7 @@ def test_relative_path(tmp_path: Path, data_path: Path) -> None:
     sm = LocalSourceManager(config, data_path)
 
     sm.sync("workflow", str(tmp_path))
-    fnames = list(f.name for f in (tmp_path).iterdir())
+    fnames = list(f.name for f in (tmp_path / "workflow").iterdir())
     assert "workflow_test.py" in fnames
     assert "__init__.py" in fnames
 
@@ -46,7 +46,7 @@ def test_relative_path_dot(tmp_path: Path, data_path: Path) -> None:
     sm = LocalSourceManager(config, data_path)
 
     sm.sync("./workflow", str(tmp_path))
-    fnames = list(f.name for f in (tmp_path).iterdir())
+    fnames = list(f.name for f in (tmp_path / "workflow").iterdir())
     assert "workflow_test.py" in fnames
     assert "__init__.py" in fnames
 


### PR DESCRIPTION
I had some trouble actually running code from installed uv dependencies. Part of the complexity here was attempting to install from a uv workspace, but there were also some bugs

1. small fix: I noticed that run_autodeploy was not actually updating the `rc_path` setting, 
2. for some reason, in `llamactl serve` environments, after `uv pip install`ing, new modules are available immediately. When testing in build container with package installed, a module reload was required
3. Local and git sync have inconsistent sync path behavior. Local sync includes the source path as a subdir of the destination, while git does not, For example:
  - copying from `./foo/bar` to `/tmp/deployments/QuickStart` will create `/tmp/deployments/QuickStart/foo/bar`. Now it just copies to `/tmp/deployments/QuickStart`
  - whereas a `https://github.com/foo/bar` will just copy the files to `/tmp/deployments/QuickStart/`
  
To account for this difference without introducing a change breaking the llama deploy deployment.yaml config, I added a `relative_path` method to the `SourceManager` as a workaround

I discovered this when attempting to sync a UI with a source of `/app/ui` (for workspace support reasons). The UI sync sort of has an assumption currently that the UI is only ever in `/ui`, and this local folder path copying was embedded into it. It's `source` path was somewhat ignored, and always attempted to run `pnpm` from a cwd of `target_folder / "ui"`. This now instead resolves the cwd of `pnpm` commands to the `target_folder / relative_path`

4. Finally, the UI file sync is currently overwriting the previously cloned python workflow code. This mostly works, as the code is already loaded into memory, so it doesn't seem to cause issues? However as a safeguard, I added the option to instead merge in the UI via a `sync_policy` (This is also a somewhat unstable way to get the UI pnpm workspace to work, but the sync policy option seems reasonable either way)