### PR TITLE
Specify file instead of globbing

### DIFF
--- a/docker/run_autodeploy.py
+++ b/docker/run_autodeploy.py
@@ -101,7 +101,12 @@ if __name__ == "__main__":
 
     setup_repo(work_dir, repo_url, repo_token)
 
-    deployment_file_path = os.environ.get("DEPLOYMENT_FILE_PATH", "deployment.yml")
+    if not settings.deployment_file_path:
+        # first fall back to none LLAMA_DEPLOY_APISERVER_ prefixed env var (settings requires the prefix)
+        settings.deployment_file_path = os.environ.get(
+            "DEPLOYMENT_FILE_PATH", "deployment.yml"
+        )
+    deployment_file_path = settings.deployment_file_path
     deployment_file_abspath = work_dir / CLONED_REPO_FOLDER / deployment_file_path
     if not deployment_file_abspath.exists():
         raise ValueError(f"File {deployment_file_abspath} does not exist")

--- a/llama_deploy/apiserver/server.py
+++ b/llama_deploy/apiserver/server.py
@@ -26,11 +26,25 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
     logger.info(f"rc folder: {settings.rc_path}")
 
     if settings.rc_path.exists():
-        logger.info(
-            f"Browsing the rc folder {settings.rc_path} for deployments to start"
+        if settings.deployment_file_path:
+            logger.info(
+                f"Browsing the rc folder {settings.rc_path} for deployment file {settings.deployment_file_path}"
+            )
+        else:
+            logger.info(
+                f"Browsing the rc folder {settings.rc_path} for deployments to start"
+            )
+
+        # if a deployment_file_path is provided, use it, otherwise glob all .yml/.yaml files
+        # q match both .yml and .yaml files with the glob
+        files = (
+            [settings.rc_path / settings.deployment_file_path]
+            if settings.deployment_file_path
+            else [
+                x for x in settings.rc_path.iterdir() if x.suffix in (".yml", ".yaml")
+            ]
         )
-        # match both .yml and .yaml files with the glob
-        for yaml_file in settings.rc_path.glob("*.y*ml"):
+        for yaml_file in files:
             try:
                 logger.info(f"Deploying startup configuration from {yaml_file}")
                 config = DeploymentConfig.from_yaml(yaml_file)

--- a/llama_deploy/apiserver/settings.py
+++ b/llama_deploy/apiserver/settings.py
@@ -23,6 +23,10 @@ class ApiserverSettings(BaseSettings):
         default=None,
         description="Path to the folder where deployments will create their root path, defaults to a temp dir",
     )
+    deployment_file_path: str | None = Field(
+        default=None,
+        description="Optional path, relative to the rc_path, where the deployment file is located. If not provided, will glob all .yml/.yaml files in the rc_path",
+    )
     use_tls: bool = Field(
         default=False,
         description="Use TLS (HTTPS) to communicate with the API Server",

--- a/tests/apiserver/test_server.py
+++ b/tests/apiserver/test_server.py
@@ -25,6 +25,7 @@ async def test_lifespan(
     with mock.patch("llama_deploy.apiserver.server.settings") as mocked_settings:
         mocked_settings.rc_path = tmp_path
         mocked_settings.deployments_path = tmp_path / "foo/bar"
+        mocked_settings.deployment_file_path = None
         mocked_manager.deployments_path = mocked_settings.deployments_path
         caplog.set_level(logging.INFO)
         async with lifespan(mock.AsyncMock()):
@@ -36,3 +37,45 @@ async def test_lifespan(
         )
         assert f"Deploying startup configuration from {config_file}" in caplog.text
         mocked_manager.serve.assert_called_once()
+
+
+@pytest.mark.asyncio
+@mock.patch("llama_deploy.apiserver.server.manager")
+async def test_lifespan_with_specific_deployment_file(
+    mocked_manager: Any,
+    tmp_path: Path,
+    caplog: Any,
+    data_path: Path,
+) -> None:
+    """Test that when deployment_file_path is specified, only that file is deployed."""
+    source_file = data_path / "git_service.yaml"
+
+    # Create target deployment file
+    target_file = tmp_path / "deployment.yml"
+    with open(target_file, "w") as f:
+        f.write(source_file.read_text())
+
+    # Create other yaml files that should be ignored
+    other_file = tmp_path / "other.yaml"
+    with open(other_file, "w") as f:
+        f.write(source_file.read_text())
+
+    mocked_manager.serve = mock.AsyncMock()
+    mocked_manager.deploy = mock.AsyncMock()
+
+    with mock.patch("llama_deploy.apiserver.server.settings") as mocked_settings:
+        mocked_settings.rc_path = tmp_path
+        mocked_settings.deployment_file_path = "deployment.yml"
+        mocked_settings.deployments_path = tmp_path / "foo/bar"
+        mocked_manager.deployments_path = mocked_settings.deployments_path
+        caplog.set_level(logging.INFO)
+
+        async with lifespan(mock.AsyncMock()):
+            pass
+
+        # Verify only the specific file was deployed
+        assert f"Deploying startup configuration from {target_file}" in caplog.text
+        assert f"Deploying startup configuration from {other_file}" not in caplog.text
+
+        # Should be called once for the specific file
+        mocked_manager.deploy.assert_called_once()


### PR DESCRIPTION
Add ability able to specify the deployment to create, rather than globbing, e.g. in the case where the run_autodeploy already has the deployment to create