### PR TITLE
Install pyprojects as editable

### DIFF
--- a/llama_deploy/apiserver/deployment.py
+++ b/llama_deploy/apiserver/deployment.py
@@ -301,15 +301,18 @@ class Deployment:
                 resolved_dep = source_root / dep
                 install_args.extend(["-r", str(resolved_dep)])
             else:
-                or_resolved = dep
                 if "." in dep or "/" in dep:
                     Deployment._validate_path_is_safe(
                         dep, source_root, "dependency path"
                     )
                     resolved_dep = source_root / dep
-                    if os.path.isfile(resolved_dep):
-                        or_resolved = str(resolved_dep.resolve())
-                install_args.append(or_resolved)
+                    if os.path.isfile(resolved_dep) or os.path.isdir(resolved_dep):
+                        # install as editable, such that sources are left in place, and can reference repository files
+                        install_args.extend(["-e", str(resolved_dep.resolve())])
+                    else:
+                        install_args.append(dep)
+                else:
+                    install_args.append(dep)
 
         # Check if uv is available on the path
         uv_available = False

--- a/tests/apiserver/test_deployment.py
+++ b/tests/apiserver/test_deployment.py
@@ -156,6 +156,7 @@ def test__install_dependencies_kitchen_sink(data_path: Path) -> None:
             "test<1",
             "-r",
             str(data_path / "bar/requirements.txt"),
+            "-e",
             str(data_path / "foo/bar/"),
         ]
 
@@ -425,6 +426,7 @@ def test__install_dependencies_mixed_path_types(
             "regular-package>=1.0.0",
             "-r",
             str(tmp_path / "test_requirements.txt"),
+            "-e",
             str(tmp_path / "test_project/"),
             "package-with-version<2.0",
         ]


### PR DESCRIPTION
When installing requirements from a pyproject.toml, it also ends up installing the application sources as non-editable. This moves the python files into `lib/python-*/site-packages`, and makes it difficult to read non python source files that were bundled with the app (json, etc.).

This changes directory/file installs as editable