### PR TITLE
fix: allow plain http

### DIFF
--- a/docker/run_autodeploy.py
+++ b/docker/run_autodeploy.py
@@ -97,8 +97,8 @@ if __name__ == "__main__":
         start_http_server(settings.prometheus_port)
 
     repo_url = os.environ.get("REPO_URL", "")
-    if not repo_url.startswith("https://"):
-        raise ValueError("Git remote must be valid and over HTTPS")
+    if not repo_url.startswith("https://") and not repo_url.startswith("http://"):
+        raise ValueError("Git remote must HTTP(S)")
     repo_token = os.environ.get("GITHUB_PAT")
     work_dir = Path(os.environ.get("WORK_DIR", RC_PATH))
     work_dir.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
Want to be able to clone git repositories inside of a private network. HTTPS requirement makes this difficult