### PR TITLE
fix(apiserver): add optional API key authentication to deployment endpoints

### DIFF
--- a/llama_deploy/apiserver/app.py
+++ b/llama_deploy/apiserver/app.py
@@ -1,10 +1,12 @@
 import logging
 import os
+import secrets
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Security, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.requests import Request
 from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from .routers import deployments_router, status_router
 from .server import lifespan
@@ -12,6 +14,29 @@ from .settings import settings
 from .tracing import configure_tracing
 
 logger = logging.getLogger("uvicorn.info")
+
+_bearer = HTTPBearer(auto_error=False)
+
+
+def get_api_key(
+    credentials: HTTPAuthorizationCredentials | None = Security(_bearer),
+) -> None:
+    """FastAPI dependency that validates the Bearer token when an API key is configured.
+
+    When ``LLAMA_DEPLOY_APISERVER_API_KEY`` is not set, all requests are allowed through
+    (backward-compatible for local development). When the env var is set, requests must
+    supply a matching ``Authorization: Bearer <key>`` header.
+    """
+    if settings.api_key is None:
+        return  # auth disabled — local dev mode
+    if credentials is None or not secrets.compare_digest(
+        credentials.credentials, settings.api_key
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 app = FastAPI(lifespan=lifespan)
@@ -29,7 +54,7 @@ if not os.environ.get("DISABLE_CORS", False):
         allow_headers=["Content-Type", "Authorization"],
     )
 
-app.include_router(deployments_router)
+app.include_router(deployments_router, dependencies=[Security(get_api_key)])
 app.include_router(status_router)
 
 

--- a/llama_deploy/apiserver/settings.py
+++ b/llama_deploy/apiserver/settings.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -30,6 +31,12 @@ class ApiserverSettings(BaseSettings):
     use_tls: bool = Field(
         default=False,
         description="Use TLS (HTTPS) to communicate with the API Server",
+    )
+    api_key: Optional[str] = Field(
+        default=None,
+        description="Optional API key for authenticating requests to the API Server. "
+        "When set, all /deployments/* endpoints require an 'Authorization: Bearer <key>' header. "
+        "When unset (default), no authentication is required (suitable for local development only).",
     )
 
     # Metrics collection settings


### PR DESCRIPTION
## Problem

The API server exposes all deployment management endpoints (including `POST /deployments/create`) 
without any authentication. An unauthenticated attacker who can reach the server can upload a 
deployment configuration pointing to an attacker-controlled git repository, causing the server 
to clone and execute arbitrary Python code.

Attack chain:
1. `POST /deployments/create` with a YAML config containing `source.type: git` and 
   `source.location: <attacker-repo>`
2. Server calls `GitSourceManager.sync()` → `git.Repo.clone_from(url=<attacker-repo>)`
3. Server calls `importlib.import_module(<module-from-cloned-repo>)` → arbitrary code execution

No credentials are required. The default deployment config binds to `127.0.0.1`, but production 
Docker and cloud deployments typically expose the port publicly.

## Fix

Add an optional `LLAMA_DEPLOY_APISERVER_API_KEY` environment variable. When set, all 
`/deployments/*` routes require a matching `Authorization: Bearer <key>` header. When unset, 
the server behaves as before (backward-compatible for local dev).

Key changes:
- `settings.py`: add `api_key: str | None = None` to `ApiserverSettings`
- `app.py`: add `get_api_key` dependency that validates the header when `api_key` is set
- `routers/deployments.py`: inject `Depends(get_api_key)` on all mutating endpoints

## Test Plan

- [ ] Existing test suite passes (tests use `Manager` directly, not the HTTP layer)
- [ ] New test: `POST /deployments/create` without key returns 401 when `LLAMA_DEPLOY_APISERVER_API_KEY` is set
- [ ] New test: `POST /deployments/create` with correct key succeeds
- [ ] `GET /` and `GET /status` remain unauthenticated (health check endpoints)

## Security Note

CVSS 3.1: AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H = 10.0 (Critical)

This is a hardening PR — the API key is optional and off by default for backward compatibility.
Operators who expose the API server to untrusted networks should set `LLAMA_DEPLOY_APISERVER_API_KEY`.