### PR TITLE
docs: document service source types

### DIFF
--- a/docs/docs/module_guides/llama_deploy/20_core_components.md
+++ b/docs/docs/module_guides/llama_deploy/20_core_components.md
@@ -34,6 +34,36 @@ services:
 
 For more details, see the API reference for the deployment [`Config`](../../api_reference/llama_deploy/apiserver.md#llama_deploy.apiserver.deployment_config_parser.DeploymentConfig) object.
 
+### Service source types
+
+Each service declares where LlamaDeploy should load its workflow code from with the `source` field. The currently implemented source managers are `local` and `git`.
+
+Use `local` when the workflow code lives next to the deployment file:
+
+```yaml
+services:
+  my_workflow:
+    name: My Workflow
+    source:
+      type: local
+      location: src
+    import-path: workflow:my_workflow
+```
+
+Use `git` when the workflow code should be cloned from a remote repository. A branch can be selected by appending `@branch_name` to the repository URL:
+
+```yaml
+services:
+  my_workflow:
+    name: My Workflow
+    source:
+      type: git
+      location: https://github.com/example/my-workflow.git@main
+    import-path: src/workflow:my_workflow
+```
+
+`local` sources copy `location` under the deployment directory and import from that relative path. `git` sources clone the repository directly into the deployment directory. For non-local deployments, sources are replaced on sync by default; `local` sources can also use `sync_policy: merge` or `sync_policy: skip` when appropriate.
+
 ## API Server
 
 The API Server is a core component of LlamaDeploy responsible for serving and managing multiple deployments at the same time,


### PR DESCRIPTION
## Summary
- document the currently implemented service source types (`local` and `git`)
- add deployment YAML examples using the current `source.type`, `source.location`, and `import-path` fields
- note the git branch suffix syntax and local/git sync behavior differences

Closes #279

## Test Plan
- `python3 - <<'PY' ...` parsed all YAML snippets in `docs/docs/module_guides/llama_deploy/20_core_components.md`
- `UV_PYTHON=/usr/local/bin/python3.11 uv run --python /usr/local/bin/python3.11 -- python - <<'PY' ...` validated the new `local` and `git` examples with `DeploymentConfig.from_yaml_bytes`

Note: an initial `uv run` without pinning Python selected Python 3.14 and failed building `tiktoken==0.9.0` because no Rust compiler was available. Re-running the scoped validation with Python 3.11 passed.
